### PR TITLE
Feature Flags Support

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,15 @@
 
 An opinionated [.NET Configuration Provider](https://learn.microsoft.com/en-us/dotnet/core/extensions/configuration-providers) for AWS AppConfig.
 
+This configuration provider supports the following freeform configuration profile type formats:
+
+- JSON
+- YAML
+
+This provider also supports the Feature Flag configuration profile type and renders
+[.NET FeatureManagement](https://github.com/microsoft/FeatureManagement-Dotnet)-compatible configuration.
+Please refer to the [Feature Flag](#feature-flags) section below for more information.
+
 ## Usage
 
 First, download the provider from NuGet:
@@ -25,7 +34,7 @@ builder.Configuration.AddAppConfig("MyCustomName");
 
 ## Configuration
 
-The provider requires some minimal configuration in order for it to know which AppConfig profiles to load: 
+The provider requires some minimal configuration in order for it to know which AppConfig profiles to load:
 
 ```json
 {
@@ -60,16 +69,105 @@ The default `ReloadAfter` setting can be overridden as well:
 }
 ```
 
+### Feature Flags
+
+[Feature Flag](https://docs.aws.amazon.com/appconfig/latest/userguide/appconfig-creating-configuration-and-profile-feature-flags.html) configuration profile types
+can be consumed by the provider and are automatically translated to .NET FeatureManagement-compatible configuration. Both simple and complex feature flags are supported.
+
+To specify feature flag profiles, add the profile metadata to the `FeatureFlags` array instead of `Profiles`:
+
+```json5
+{
+  "AppConfig": {
+    "Profiles": [
+      // Freeform configuration profile
+      "abc1234:def5678:ghi9123",
+      // Freeform configuration profile
+      "q2w3e25:po92j45:bt9s090:300"
+    ],
+    "FeatureFlags": [
+      // Feature Flag profile
+      "bvt1234:glw6348:zup8532"
+    ]
+  }
+}
+```
+
+Due to the differences between the AppConfig and FeatureManagement configuration setup and the validation constraints that AppConfig uses for feature flags,
+the provider has some opinionated quirks when it comes to feature flags.
+
+**Simple Flags**
+
+A "simple" flag is one that can be enabled or disabled and does not contain any attributes.
+AppConfig returns these as an object with a single field:
+
+```json
+{
+  "customFeatureFlag": {
+    "enabled": true
+  }
+}
+```
+
+This gets translated to:
+
+```json
+{
+  "FeatureManagement": {
+    "CustomFeatureFlag": true
+  }
+}
+```
+
+The provider will automatically convert the name of the flag to PascalCase.
+
+**Complex Flags**
+
+A "complex" flag is one that contains attributes that specify feature filters and, optionally, their parameters.
+
+AppConfig will return these like this:
+
+```json5
+{
+  "complexFlag": {
+    "enabled": true,
+    "customProperty": "customValue",
+    // etc.
+  }
+}
+```
+
+To get around some of the limitations of how AppConfig lets you construct attributes, the following transformations rules are in place:
+
+- The feature name is the PascalCase version of the flag name
+- The `enabled` field is always ignored
+- The  `requirementType` field is converted to `RequirementType`
+  - It must be either `All` or `Any` (default if omitted)
+- Any other fields are considered to be feature filters and/or their parameters
+  - A parameterless filter should be named `featureFilter` and have a blank/null value (e.g. `"alwaysOn": null`)
+  - A filter with parameters should be named `featureFilter__parameterName` and have a value for the parameter (e.g. `"percentage__value": 50`)
+    - The provider uses the double underscore (`__`) to separate the filter name from the parameter name
+    - You can supply multiple parameters using this scheme (e.g. `"percentage__value": 50, "percentage__foobar": "baz"`)
+
+There are likely to be some limitations with this approach, so please open an issue if you find any that don't match your use case.
+
 ## Sample
 
 A sample ASP.NET Web Application is available in the `samples/AppConfigTesting` folder.
 
 In your own AWS environment, copy the contents of `yamltest.yml` into a new AppConfig freeform configuration profile.
 
+Then, create a new Feature Flag configuration profile with 2 flags: `enableFoobar` and `complexFlag`.  
+Feel free to add any attributes you want to `complexFlag` that match the rules described in the [Feature Flags](#feature-flags) section.
+
 Then, use `dotnet user-secrets` to specify the AppConfig profile:
 
 ```shell
-dotnet user-secrets set "AppConfig:Profiles:0" "abc1234:def5678:ghi9123"
+# Freeform configuration profile
+dotnet user-secrets set "AppConfig:Profiles:0" "abc1234:def5678:ghi9123" # <-- Replace with your own profile
+
+# Feature Flag configuration profile
+dotnet user-secrets set "AppConfig:FeatureFlags:0" "bvt1234:glw6348:zup8532" # <-- Replace with your own profile
 ```
 
 Finally, ensure that you have the correct AWS credentials/profile configured in your environment, and run the sample:

--- a/samples/AppConfigTesting/AppConfigTesting.csproj
+++ b/samples/AppConfigTesting/AppConfigTesting.csproj
@@ -11,4 +11,8 @@
     <ProjectReference Include="..\..\src\CatConsult.AppConfigConfigurationProvider\CatConsult.AppConfigConfigurationProvider.csproj" />
   </ItemGroup>
 
+  <ItemGroup>
+    <PackageReference Include="Microsoft.FeatureManagement.AspNetCore" Version="3.1.1" />
+  </ItemGroup>
+
 </Project>

--- a/samples/AppConfigTesting/Pages/Index.cshtml
+++ b/samples/AppConfigTesting/Pages/Index.cshtml
@@ -1,14 +1,46 @@
 ﻿@page
 @using Microsoft.Extensions.Options
+@using Microsoft.FeatureManagement
 @model IndexModel
 @inject IOptionsSnapshot<YamlTest> Options
+@inject IFeatureManager FeatureManager
 @{
     ViewData["Title"] = "Home page";
 }
 
 <div class="text-center">
+    <h2>YAML Configuration</h2>
+
     <p>Name: @Options.Value.Person?.Name</p>
     <p>Age: @Options.Value.Person?.Age</p>
     <br>
     <p>Is this a test? @Options.Value.Test</p>
+</div>
+
+<div class="mt-3 text-center">
+    <h2>Features</h2>
+
+    <h3>Registered Features</h3>
+    @await foreach (var feature in FeatureManager.GetFeatureNamesAsync())
+    {
+        <p>
+            <code>@feature</code>
+        </p>
+    }
+
+    <h3>Enabled Features</h3>
+
+    <feature name="EnableFoobar">
+        <p><code>EnableFoobar</code> is enabled</p>
+    </feature>
+    <feature name="EnableFoobar" negate="true">
+        <p><code>EnableFoobar</code> is <b>not</b> enabled</p>
+    </feature>
+
+    <feature name="ComplexFlag">
+        <p><code>ComplexFlag</code> is enabled</p>
+    </feature>
+    <feature name="ComplexFlag" negate="true">
+        <p><code>ComplexFlag</code> is <b>not</b> enabled</p>
+    </feature>
 </div>

--- a/samples/AppConfigTesting/Pages/_ViewImports.cshtml
+++ b/samples/AppConfigTesting/Pages/_ViewImports.cshtml
@@ -1,3 +1,4 @@
 ﻿@using AppConfigTesting
 @namespace AppConfigTesting.Pages
 @addTagHelper *, Microsoft.AspNetCore.Mvc.TagHelpers
+@addTagHelper *, Microsoft.FeatureManagement.AspNetCore

--- a/samples/AppConfigTesting/Program.cs
+++ b/samples/AppConfigTesting/Program.cs
@@ -1,7 +1,6 @@
 using CatConsult.AppConfigConfigurationProvider;
 
 using Microsoft.FeatureManagement;
-using Microsoft.FeatureManagement.FeatureFilters;
 
 var builder = WebApplication.CreateBuilder(args);
 
@@ -13,9 +12,7 @@ builder.Services.AddRazorPages();
 builder.Services.AddOptions<YamlTest>()
     .BindConfiguration("YamlTest");
 
-builder.Services.AddFeatureManagement()
-    .AddFeatureFilter<TimeWindowFilter>()
-    .AddFeatureFilter<PercentageFilter>();
+builder.Services.AddFeatureManagement();
 
 var app = builder.Build();
 

--- a/samples/AppConfigTesting/Program.cs
+++ b/samples/AppConfigTesting/Program.cs
@@ -1,5 +1,8 @@
 using CatConsult.AppConfigConfigurationProvider;
 
+using Microsoft.FeatureManagement;
+using Microsoft.FeatureManagement.FeatureFilters;
+
 var builder = WebApplication.CreateBuilder(args);
 
 builder.Configuration.AddAppConfig();
@@ -9,6 +12,10 @@ builder.Services.AddRazorPages();
 
 builder.Services.AddOptions<YamlTest>()
     .BindConfiguration("YamlTest");
+
+builder.Services.AddFeatureManagement()
+    .AddFeatureFilter<TimeWindowFilter>()
+    .AddFeatureFilter<PercentageFilter>();
 
 var app = builder.Build();
 

--- a/samples/AppConfigTesting/appsettings.Development.json
+++ b/samples/AppConfigTesting/appsettings.Development.json
@@ -7,10 +7,7 @@
   },
   "AppConfig": {
     "Defaults": {
-      "ReloadAfter": 60,
-      "FeatureFlags": {
-        "SectionName": "FeatureManagement"
-      }
+      "ReloadAfter": 60
     },
     "Profiles": [],
     "FeatureFlags": []

--- a/samples/AppConfigTesting/appsettings.Development.json
+++ b/samples/AppConfigTesting/appsettings.Development.json
@@ -7,8 +7,12 @@
   },
   "AppConfig": {
     "Defaults": {
-      "ReloadAfter": 60
+      "ReloadAfter": 60,
+      "FeatureFlags": {
+        "SectionName": "FeatureManagement"
+      }
     },
-    "Profiles": []
+    "Profiles": [],
+    "FeatureFlags": []
   }
 }

--- a/src/CatConsult.AppConfigConfigurationProvider/AppConfigConfigurationProvider.cs
+++ b/src/CatConsult.AppConfigConfigurationProvider/AppConfigConfigurationProvider.cs
@@ -81,6 +81,7 @@ public sealed class AppConfigConfigurationProvider : ConfigurationProvider, IDis
             if (response.ContentLength > 0)
             {
                 Data = ParseConfig(response.Configuration, response.ContentType);
+                OnReload();
             }
         }
         finally
@@ -118,4 +119,13 @@ public sealed class AppConfigConfigurationProvider : ConfigurationProvider, IDis
     }
 
     public void Dispose() => _reloadChangeToken?.Dispose();
+
+    public override string ToString()
+    {
+        var className = GetType().Name;
+        var profile = $"{_profile.ApplicationId}:{_profile.EnvironmentId}:{_profile.ProfileId}:{_profile.ReloadAfter}";
+        var isFeatureFlag = _profile.IsFeatureFlag ? " (Feature Flag)" : string.Empty;
+
+        return $"{className} - {profile}{isFeatureFlag}";
+    }
 }

--- a/src/CatConsult.AppConfigConfigurationProvider/AppConfigConfigurationProvider.cs
+++ b/src/CatConsult.AppConfigConfigurationProvider/AppConfigConfigurationProvider.cs
@@ -1,6 +1,7 @@
 using Amazon.AppConfigData;
 using Amazon.AppConfigData.Model;
 
+using CatConsult.AppConfigConfigurationProvider.Utilities;
 using CatConsult.ConfigurationParsers;
 
 using Microsoft.Extensions.Configuration;
@@ -100,7 +101,7 @@ public sealed class AppConfigConfigurationProvider : ConfigurationProvider, IDis
         ConfigurationToken = session.InitialConfigurationToken;
     }
 
-    private static IDictionary<string, string?> ParseConfig(Stream stream, string? contentType)
+    private IDictionary<string, string?> ParseConfig(Stream stream, string? contentType)
     {
         if (!string.IsNullOrEmpty(contentType))
         {
@@ -109,6 +110,7 @@ public sealed class AppConfigConfigurationProvider : ConfigurationProvider, IDis
 
         return contentType switch
         {
+            "application/json" when _profile.IsFeatureFlag => FeatureFlagsProfileParser.Parse(stream),
             "application/json" => JsonConfigurationParser.Parse(stream),
             "application/x-yaml" => YamlConfigurationParser.Parse(stream),
             _ => throw new FormatException($"This configuration provider does not support: {contentType ?? "Unknown"}")

--- a/src/CatConsult.AppConfigConfigurationProvider/AppConfigOptions.cs
+++ b/src/CatConsult.AppConfigConfigurationProvider/AppConfigOptions.cs
@@ -4,10 +4,19 @@ public class AppConfigOptions
 {
     public List<string> Profiles { get; set; } = new();
 
+    public List<string> FeatureFlags { get; set; } = new();
+
     public Defaults Defaults { get; set; } = new();
 }
 
 public class Defaults
 {
     public int ReloadAfter { get; set; } = 60;
+
+    public FeatureFlagDefaults FeatureFlags { get; set; } = new();
+}
+
+public class FeatureFlagDefaults
+{
+    public string SectionName { get; set; } = "FeatureManagement";
 }

--- a/src/CatConsult.AppConfigConfigurationProvider/AppConfigOptions.cs
+++ b/src/CatConsult.AppConfigConfigurationProvider/AppConfigOptions.cs
@@ -12,11 +12,4 @@ public class AppConfigOptions
 public class Defaults
 {
     public int ReloadAfter { get; set; } = 60;
-
-    public FeatureFlagDefaults FeatureFlags { get; set; } = new();
-}
-
-public class FeatureFlagDefaults
-{
-    public string SectionName { get; set; } = "FeatureManagement";
 }

--- a/src/CatConsult.AppConfigConfigurationProvider/AppConfigProfile.cs
+++ b/src/CatConsult.AppConfigConfigurationProvider/AppConfigProfile.cs
@@ -2,5 +2,7 @@ namespace CatConsult.AppConfigConfigurationProvider;
 
 public record AppConfigProfile(string ApplicationId, string EnvironmentId, string ProfileId)
 {
+    public bool IsFeatureFlag { get; set; }
+
     public int? ReloadAfter { get; set; }
 }

--- a/src/CatConsult.AppConfigConfigurationProvider/CatConsult.AppConfigConfigurationProvider.csproj
+++ b/src/CatConsult.AppConfigConfigurationProvider/CatConsult.AppConfigConfigurationProvider.csproj
@@ -24,6 +24,7 @@
   <ItemGroup>
     <PackageReference Include="AWSSDK.AppConfigData" Version="3.7.300.16" />
     <PackageReference Include="CatConsult.ConfigurationParsers" Version="2.1.0" />
+    <PackageReference Include="Humanizer.Core" Version="2.14.1" />
     <PackageReference Include="Microsoft.Extensions.Configuration" Version="6.0.0" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="6.0.0" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="6.0.0" />

--- a/src/CatConsult.AppConfigConfigurationProvider/FeatureFlagsProfile.cs
+++ b/src/CatConsult.AppConfigConfigurationProvider/FeatureFlagsProfile.cs
@@ -1,0 +1,18 @@
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+namespace CatConsult.AppConfigConfigurationProvider;
+
+public class FeatureFlagsProfile : Dictionary<string, FeatureFlag>
+{
+}
+
+public class FeatureFlag
+{
+    public bool Enabled { get; set; }
+
+    public string? RequirementType { get; set; }
+
+    [JsonExtensionData]
+    public Dictionary<string, JsonElement>? ExtraProperties { get; set; }
+}

--- a/src/CatConsult.AppConfigConfigurationProvider/Utilities/AppConfigProfileParser.cs
+++ b/src/CatConsult.AppConfigConfigurationProvider/Utilities/AppConfigProfileParser.cs
@@ -7,7 +7,7 @@ internal static class AppConfigProfileParser
     private const string ProfileStringFormat = "ApplicationId:EnvironmentId:ProfileId[:ReloadAfter]";
     private const string ProfileStringPattern = @"([a-z0-9]{7}):([a-z0-9]{7}):([a-z0-9]{7}):?(\d+)?";
 
-    public static AppConfigProfile Parse(string profileString, int defaultReloadAfter)
+    public static AppConfigProfile Parse(string profileString, bool isFeatureFlag, int defaultReloadAfter)
     {
         var match = Regex.Match(profileString, ProfileStringPattern);
 
@@ -26,6 +26,7 @@ internal static class AppConfigProfileParser
         var profile = new AppConfigProfile(applicationId, environmentId, profileId)
         {
             ReloadAfter = defaultReloadAfter,
+            IsFeatureFlag = isFeatureFlag,
         };
 
         if (int.TryParse(reloadAfterString, out var reloadAfter))

--- a/src/CatConsult.AppConfigConfigurationProvider/Utilities/FeatureFlagsProfileParser.cs
+++ b/src/CatConsult.AppConfigConfigurationProvider/Utilities/FeatureFlagsProfileParser.cs
@@ -13,30 +13,35 @@ internal class FeatureFlagsProfileParser : ConfigurationParser
         PropertyNameCaseInsensitive = true,
     };
 
-    private FeatureFlagsProfileParser() { }
+    private readonly string _sectionName;
 
-    public static IDictionary<string, string?> Parse(string json)
+    private FeatureFlagsProfileParser(string sectionName)
+    {
+        _sectionName = sectionName;
+    }
+
+    public static IDictionary<string, string?> Parse(string sectionName, string json)
     {
         var featureFlagProfile = JsonSerializer.Deserialize<FeatureFlagsProfile>(json, JsonSerializerOptions);
 
-        return Parse(featureFlagProfile);
+        return Parse(sectionName, featureFlagProfile);
     }
 
-    public static IDictionary<string, string?> Parse(Stream stream)
+    public static IDictionary<string, string?> Parse(string sectionName, Stream stream)
     {
         var featureFlagProfile = JsonSerializer.Deserialize<FeatureFlagsProfile>(stream, JsonSerializerOptions);
 
-        return Parse(featureFlagProfile);
+        return Parse(sectionName, featureFlagProfile);
     }
 
-    private static IDictionary<string, string?> Parse(FeatureFlagsProfile? profile)
+    private static IDictionary<string, string?> Parse(string sectionName, FeatureFlagsProfile? profile)
     {
         if (profile is null)
         {
             return new Dictionary<string, string?>();
         }
 
-        var parser = new FeatureFlagsProfileParser();
+        var parser = new FeatureFlagsProfileParser(sectionName);
         parser.ParseInternal(profile);
 
         return parser.Data;
@@ -44,7 +49,7 @@ internal class FeatureFlagsProfileParser : ConfigurationParser
 
     private void ParseInternal(FeatureFlagsProfile profile)
     {
-        PushContext("FeatureManagement");
+        PushContext(_sectionName);
 
         foreach ((string name, FeatureFlag flag) in profile)
         {
@@ -137,7 +142,7 @@ internal class FeatureFlagsProfileParser : ConfigurationParser
                 JsonValueKind.Undefined => null,
                 _ => value.ToString(),
             };
-                
+
             parameters.Add(parameterName, parameterValue);
         }
 

--- a/src/CatConsult.AppConfigConfigurationProvider/Utilities/FeatureFlagsProfileParser.cs
+++ b/src/CatConsult.AppConfigConfigurationProvider/Utilities/FeatureFlagsProfileParser.cs
@@ -13,35 +13,30 @@ internal class FeatureFlagsProfileParser : ConfigurationParser
         PropertyNameCaseInsensitive = true,
     };
 
-    private readonly string _sectionName;
+    private FeatureFlagsProfileParser() { }
 
-    private FeatureFlagsProfileParser(string sectionName)
-    {
-        _sectionName = sectionName;
-    }
-
-    public static IDictionary<string, string?> Parse(string sectionName, string json)
+    public static IDictionary<string, string?> Parse(string json)
     {
         var featureFlagProfile = JsonSerializer.Deserialize<FeatureFlagsProfile>(json, JsonSerializerOptions);
 
-        return Parse(sectionName, featureFlagProfile);
+        return Parse(featureFlagProfile);
     }
 
-    public static IDictionary<string, string?> Parse(string sectionName, Stream stream)
+    public static IDictionary<string, string?> Parse(Stream stream)
     {
         var featureFlagProfile = JsonSerializer.Deserialize<FeatureFlagsProfile>(stream, JsonSerializerOptions);
 
-        return Parse(sectionName, featureFlagProfile);
+        return Parse(featureFlagProfile);
     }
 
-    private static IDictionary<string, string?> Parse(string sectionName, FeatureFlagsProfile? profile)
+    private static IDictionary<string, string?> Parse(FeatureFlagsProfile? profile)
     {
         if (profile is null)
         {
             return new Dictionary<string, string?>();
         }
 
-        var parser = new FeatureFlagsProfileParser(sectionName);
+        var parser = new FeatureFlagsProfileParser();
         parser.ParseInternal(profile);
 
         return parser.Data;
@@ -49,7 +44,7 @@ internal class FeatureFlagsProfileParser : ConfigurationParser
 
     private void ParseInternal(FeatureFlagsProfile profile)
     {
-        PushContext(_sectionName);
+        PushContext("FeatureManagement");
 
         foreach ((string name, FeatureFlag flag) in profile)
         {

--- a/src/CatConsult.AppConfigConfigurationProvider/Utilities/FeatureFlagsProfileParser.cs
+++ b/src/CatConsult.AppConfigConfigurationProvider/Utilities/FeatureFlagsProfileParser.cs
@@ -73,10 +73,12 @@ internal class FeatureFlagsProfileParser : ConfigurationParser
         PopContext();
 
         // Then we can populate the "EnabledFor" array
+        PushContext("EnabledFor");
+
         var i = 0;
         foreach ((string featureFilter, Dictionary<string, string?> parameters) in ProcessFeatureFilters(flag.ExtraProperties))
         {
-            PushContext($"EnabledFor[{i}]");
+            PushContext(i);
 
             PushContext("Name");
             SetValue(featureFilter.Pascalize());
@@ -92,10 +94,12 @@ internal class FeatureFlagsProfileParser : ConfigurationParser
 
             PopContext(); // Parameters
 
-            PopContext(); // EnabledFor[i]
+            PopContext(); // i
 
             i++;
         }
+
+        PopContext(); // EnabledFor
     }
 
     private static Dictionary<string, Dictionary<string, string?>> ProcessFeatureFilters(IDictionary<string, JsonElement> extraProperties)

--- a/test/CatConsult.AppConfigConfigurationProvider.Tests/AppConfigConfigurationProviderTests.cs
+++ b/test/CatConsult.AppConfigConfigurationProvider.Tests/AppConfigConfigurationProviderTests.cs
@@ -149,11 +149,11 @@ public class AppConfigConfigurationProviderTests
         VerifyValue(sut, $"{prefix}:ComplexFlag3:RequirementType", "Any");
 
         VerifyValue(sut, $"{prefix}:EdgeCase1:RequirementType", "Any");
-        VerifyValue(sut, $"{prefix}:EdgeCase1:EnabledFor[0]:Name", "AlwaysOn");
+        VerifyValue(sut, $"{prefix}:EdgeCase1:EnabledFor:0:Name", "AlwaysOn");
         
         VerifyValue(sut, $"{prefix}:EdgeCase2:RequirementType", "Any");
-        VerifyValue(sut, $"{prefix}:EdgeCase2:EnabledFor[0]:Name", "Foobar");
-        VerifyValue(sut, $"{prefix}:EdgeCase2:EnabledFor[0]:Parameters:Value", null);
+        VerifyValue(sut, $"{prefix}:EdgeCase2:EnabledFor:0:Name", "Foobar");
+        VerifyValue(sut, $"{prefix}:EdgeCase2:EnabledFor:0:Parameters:Value", null);
     }
 
     // Helper methods

--- a/test/CatConsult.AppConfigConfigurationProvider.Tests/AppConfigConfigurationProviderTests.cs
+++ b/test/CatConsult.AppConfigConfigurationProvider.Tests/AppConfigConfigurationProviderTests.cs
@@ -5,6 +5,8 @@ using Amazon.AppConfigData.Model;
 
 using FluentAssertions;
 
+using Microsoft.Extensions.Configuration;
+
 using Moq;
 
 namespace CatConsult.AppConfigConfigurationProvider.Tests;
@@ -110,6 +112,50 @@ public class AppConfigConfigurationProviderTests
         value.Should().Be("Catalyst");
     }
 
+    [Fact]
+    public void Load_Should_Parse_FeatureFlags()
+    {
+        var profile = new AppConfigProfile("test", "foo", "bar")
+        {
+            ReloadAfter = null, // disable auto-reload for this test
+            IsFeatureFlag = true,
+        };
+
+        var sut = new AppConfigConfigurationProvider(_mockClient.Object, profile);
+
+        _mockClient
+            .Setup(p =>
+                p.StartConfigurationSessionAsync(
+                    It.IsAny<StartConfigurationSessionRequest>(),
+                    It.IsAny<CancellationToken>()
+                )
+            ).ReturnsAsync(new StartConfigurationSessionResponse());
+
+        _mockClient.Setup(p =>
+            p.GetLatestConfigurationAsync(
+                It.IsAny<GetLatestConfigurationRequest>(),
+                It.IsAny<CancellationToken>()
+            )
+        ).ReturnsAsync(GenerateFeatureFlagResponse());
+
+        sut.Load();
+
+        const string prefix = "FeatureManagement";
+
+        VerifyValue(sut, $"{prefix}:SimpleFlag", "true");
+
+        VerifyValue(sut, $"{prefix}:ComplexFlag1:RequirementType", "Any");
+        VerifyValue(sut, $"{prefix}:ComplexFlag2:RequirementType", "All");
+        VerifyValue(sut, $"{prefix}:ComplexFlag3:RequirementType", "Any");
+
+        VerifyValue(sut, $"{prefix}:EdgeCase1:RequirementType", "Any");
+        VerifyValue(sut, $"{prefix}:EdgeCase1:EnabledFor[0]:Name", "AlwaysOn");
+        
+        VerifyValue(sut, $"{prefix}:EdgeCase2:RequirementType", "Any");
+        VerifyValue(sut, $"{prefix}:EdgeCase2:EnabledFor[0]:Name", "Foobar");
+        VerifyValue(sut, $"{prefix}:EdgeCase2:EnabledFor[0]:Parameters:Value", null);
+    }
+
     // Helper methods
 
     private static GetLatestConfigurationResponse GenerateJsonResponse() =>
@@ -117,6 +163,9 @@ public class AppConfigConfigurationProviderTests
 
     private static GetLatestConfigurationResponse GenerateYamlResponse() =>
         GenerateResponse("Name: Catalyst", "application/x-yaml");
+
+    private static GetLatestConfigurationResponse GenerateFeatureFlagResponse() =>
+        GenerateResponse(File.ReadAllText("fixtures/feature-flags.json"), "application/json");
 
     private static GetLatestConfigurationResponse GenerateResponse(string data, string contentType) =>
         new()
@@ -127,4 +176,10 @@ public class AppConfigConfigurationProviderTests
             NextPollIntervalInSeconds = -1,
             NextPollConfigurationToken = "foobar",
         };
+
+    private static void VerifyValue(IConfigurationProvider provider, string key, string? expected)
+    {
+        provider.TryGet(key, out var value).Should().BeTrue();
+        value.Should().Be(expected);
+    }
 }

--- a/test/CatConsult.AppConfigConfigurationProvider.Tests/AppConfigProfileParserTests.cs
+++ b/test/CatConsult.AppConfigConfigurationProvider.Tests/AppConfigProfileParserTests.cs
@@ -19,14 +19,14 @@ public class AppConfigProfileParserTests
 
         var profileString = string.Join(":", applicationId, environmentId, profileId);
 
-        var profile = AppConfigProfileParser.Parse(profileString, 60);
+        var profile = AppConfigProfileParser.Parse(profileString, false, 60);
 
         profile.ApplicationId.Should().Be(applicationId);
         profile.EnvironmentId.Should().Be(environmentId);
         profile.ProfileId.Should().Be(profileId);
         profile.ReloadAfter.Should().Be(60);
 
-        profile = AppConfigProfileParser.Parse(profileString + ":300", 60);
+        profile = AppConfigProfileParser.Parse(profileString + ":300", false, 60);
 
         profile.ReloadAfter.Should().Be(300);
     }
@@ -38,8 +38,26 @@ public class AppConfigProfileParserTests
     {
         const string profileString = "foo*!:bar-+;:BAZ123:`&%()";
 
-        var act = () => AppConfigProfileParser.Parse(profileString, 60);
+        var act = () => AppConfigProfileParser.Parse(profileString, false, 60);
 
         act.Should().Throw<Exception>();
+    }
+    
+    [Fact]
+    public void Parse_Sets_IsFeatureFlag()
+    {
+        var applicationId = GenerateAppConfigId();
+        var environmentId = GenerateAppConfigId();
+        var profileId = GenerateAppConfigId();
+
+        var profileString = string.Join(":", applicationId, environmentId, profileId);
+
+        var profile = AppConfigProfileParser.Parse(profileString, false, 60);
+
+        profile.IsFeatureFlag.Should().BeFalse();
+
+        profile = AppConfigProfileParser.Parse(profileString, true, 60);
+
+        profile.IsFeatureFlag.Should().BeTrue();
     }
 }

--- a/test/CatConsult.AppConfigConfigurationProvider.Tests/CatConsult.AppConfigConfigurationProvider.Tests.csproj
+++ b/test/CatConsult.AppConfigConfigurationProvider.Tests/CatConsult.AppConfigConfigurationProvider.Tests.csproj
@@ -27,5 +27,9 @@
   <ItemGroup>
     <ProjectReference Include="..\..\src\CatConsult.AppConfigConfigurationProvider\CatConsult.AppConfigConfigurationProvider.csproj" />
   </ItemGroup>
+    
+  <ItemGroup>
+    <Content Include="fixtures/*" CopyToOutputDirectory="Always" />
+  </ItemGroup>
 
 </Project>

--- a/test/CatConsult.AppConfigConfigurationProvider.Tests/FeatureFlagsProfileParserTests.cs
+++ b/test/CatConsult.AppConfigConfigurationProvider.Tests/FeatureFlagsProfileParserTests.cs
@@ -19,6 +19,13 @@ public class FeatureFlagsProfileParserTests
         ValidateComplexFlag(data, $"{prefixKey}:ComplexFlag1", "Any");
         ValidateComplexFlag(data, $"{prefixKey}:ComplexFlag2", "All");
         ValidateComplexFlag(data, $"{prefixKey}:ComplexFlag3", "Any");
+
+        data.Should().Contain($"{prefixKey}:EdgeCase1:RequirementType", "Any");
+        data.Should().Contain($"{prefixKey}:EdgeCase1:EnabledFor[0]:Name", "AlwaysOn");
+        
+        data.Should().Contain($"{prefixKey}:EdgeCase2:RequirementType", "Any");
+        data.Should().Contain($"{prefixKey}:EdgeCase2:EnabledFor[0]:Name", "Foobar");
+        data.Should().Contain($"{prefixKey}:EdgeCase2:EnabledFor[0]:Parameters:Value", null);
     }
 
     private static void ValidateComplexFlag(IDictionary<string, string?> data, string flagPrefixKey, string requirementType)

--- a/test/CatConsult.AppConfigConfigurationProvider.Tests/FeatureFlagsProfileParserTests.cs
+++ b/test/CatConsult.AppConfigConfigurationProvider.Tests/FeatureFlagsProfileParserTests.cs
@@ -1,0 +1,45 @@
+using CatConsult.AppConfigConfigurationProvider.Utilities;
+
+using FluentAssertions;
+
+namespace CatConsult.AppConfigConfigurationProvider.Tests;
+
+public class FeatureFlagsProfileParserTests
+{
+    [Fact]
+    public void Parse_Parses_AppConfig_FeatureFlag_Json()
+    {
+        var json = File.ReadAllText("fixtures/feature-flags.json");
+        var data = FeatureFlagsProfileParser.Parse(json);
+
+        const string prefixKey = "FeatureManagement";
+
+        data.Should().Contain($"{prefixKey}:SimpleFlag", "true");
+
+        ValidateComplexFlag(data, $"{prefixKey}:ComplexFlag1", "Any");
+        ValidateComplexFlag(data, $"{prefixKey}:ComplexFlag2", "All");
+        ValidateComplexFlag(data, $"{prefixKey}:ComplexFlag3", "Any");
+    }
+
+    private static void ValidateComplexFlag(IDictionary<string, string?> data, string flagPrefixKey, string requirementType)
+    {
+        data.Should().Contain($"{flagPrefixKey}:RequirementType", requirementType);
+
+        // The EnabledFor "array" is not guaranteed to be in the same order, so we have to determine the order ourselves before asserting
+        var percentageIndex = 0;
+        var timeWindowIndex = 1;
+
+        if (data[$"{flagPrefixKey}:EnabledFor[0]:Name"] != "Percentage")
+        {
+            percentageIndex = 1;
+            timeWindowIndex = 0;
+        }
+
+        data.Should().Contain($"{flagPrefixKey}:EnabledFor[{percentageIndex}]:Name", "Percentage");
+        data.Should().Contain($"{flagPrefixKey}:EnabledFor[{percentageIndex}]:Parameters:Value", "50");
+
+        data.Should().Contain($"{flagPrefixKey}:EnabledFor[{timeWindowIndex}]:Name", "TimeWindow");
+        data.Should().Contain($"{flagPrefixKey}:EnabledFor[{timeWindowIndex}]:Parameters:Start", "2023");
+        data.Should().Contain($"{flagPrefixKey}:EnabledFor[{timeWindowIndex}]:Parameters:End", "2024");
+    }
+}

--- a/test/CatConsult.AppConfigConfigurationProvider.Tests/FeatureFlagsProfileParserTests.cs
+++ b/test/CatConsult.AppConfigConfigurationProvider.Tests/FeatureFlagsProfileParserTests.cs
@@ -9,23 +9,23 @@ public class FeatureFlagsProfileParserTests
     [Fact]
     public void Parse_Parses_AppConfig_FeatureFlag_Json()
     {
+        const string sectionName = "FeatureManagementTest";
+
         var json = File.ReadAllText("fixtures/feature-flags.json");
-        var data = FeatureFlagsProfileParser.Parse(json);
+        var data = FeatureFlagsProfileParser.Parse(sectionName, json);
 
-        const string prefixKey = "FeatureManagement";
+        data.Should().Contain($"{sectionName}:SimpleFlag", "true");
 
-        data.Should().Contain($"{prefixKey}:SimpleFlag", "true");
+        ValidateComplexFlag(data, $"{sectionName}:ComplexFlag1", "Any");
+        ValidateComplexFlag(data, $"{sectionName}:ComplexFlag2", "All");
+        ValidateComplexFlag(data, $"{sectionName}:ComplexFlag3", "Any");
 
-        ValidateComplexFlag(data, $"{prefixKey}:ComplexFlag1", "Any");
-        ValidateComplexFlag(data, $"{prefixKey}:ComplexFlag2", "All");
-        ValidateComplexFlag(data, $"{prefixKey}:ComplexFlag3", "Any");
-
-        data.Should().Contain($"{prefixKey}:EdgeCase1:RequirementType", "Any");
-        data.Should().Contain($"{prefixKey}:EdgeCase1:EnabledFor[0]:Name", "AlwaysOn");
+        data.Should().Contain($"{sectionName}:EdgeCase1:RequirementType", "Any");
+        data.Should().Contain($"{sectionName}:EdgeCase1:EnabledFor[0]:Name", "AlwaysOn");
         
-        data.Should().Contain($"{prefixKey}:EdgeCase2:RequirementType", "Any");
-        data.Should().Contain($"{prefixKey}:EdgeCase2:EnabledFor[0]:Name", "Foobar");
-        data.Should().Contain($"{prefixKey}:EdgeCase2:EnabledFor[0]:Parameters:Value", null);
+        data.Should().Contain($"{sectionName}:EdgeCase2:RequirementType", "Any");
+        data.Should().Contain($"{sectionName}:EdgeCase2:EnabledFor[0]:Name", "Foobar");
+        data.Should().Contain($"{sectionName}:EdgeCase2:EnabledFor[0]:Parameters:Value", null);
     }
 
     private static void ValidateComplexFlag(IDictionary<string, string?> data, string flagPrefixKey, string requirementType)

--- a/test/CatConsult.AppConfigConfigurationProvider.Tests/FeatureFlagsProfileParserTests.cs
+++ b/test/CatConsult.AppConfigConfigurationProvider.Tests/FeatureFlagsProfileParserTests.cs
@@ -9,10 +9,10 @@ public class FeatureFlagsProfileParserTests
     [Fact]
     public void Parse_Parses_AppConfig_FeatureFlag_Json()
     {
-        const string sectionName = "FeatureManagementTest";
+        const string sectionName = "FeatureManagement";
 
         var json = File.ReadAllText("fixtures/feature-flags.json");
-        var data = FeatureFlagsProfileParser.Parse(sectionName, json);
+        var data = FeatureFlagsProfileParser.Parse(json);
 
         data.Should().Contain($"{sectionName}:SimpleFlag", "true");
 

--- a/test/CatConsult.AppConfigConfigurationProvider.Tests/FeatureFlagsProfileParserTests.cs
+++ b/test/CatConsult.AppConfigConfigurationProvider.Tests/FeatureFlagsProfileParserTests.cs
@@ -21,11 +21,11 @@ public class FeatureFlagsProfileParserTests
         ValidateComplexFlag(data, $"{sectionName}:ComplexFlag3", "Any");
 
         data.Should().Contain($"{sectionName}:EdgeCase1:RequirementType", "Any");
-        data.Should().Contain($"{sectionName}:EdgeCase1:EnabledFor[0]:Name", "AlwaysOn");
+        data.Should().Contain($"{sectionName}:EdgeCase1:EnabledFor:0:Name", "AlwaysOn");
         
         data.Should().Contain($"{sectionName}:EdgeCase2:RequirementType", "Any");
-        data.Should().Contain($"{sectionName}:EdgeCase2:EnabledFor[0]:Name", "Foobar");
-        data.Should().Contain($"{sectionName}:EdgeCase2:EnabledFor[0]:Parameters:Value", null);
+        data.Should().Contain($"{sectionName}:EdgeCase2:EnabledFor:0:Name", "Foobar");
+        data.Should().Contain($"{sectionName}:EdgeCase2:EnabledFor:0:Parameters:Value", null);
     }
 
     private static void ValidateComplexFlag(IDictionary<string, string?> data, string flagPrefixKey, string requirementType)
@@ -36,17 +36,17 @@ public class FeatureFlagsProfileParserTests
         var percentageIndex = 0;
         var timeWindowIndex = 1;
 
-        if (data[$"{flagPrefixKey}:EnabledFor[0]:Name"] != "Percentage")
+        if (data[$"{flagPrefixKey}:EnabledFor:0:Name"] != "Percentage")
         {
             percentageIndex = 1;
             timeWindowIndex = 0;
         }
 
-        data.Should().Contain($"{flagPrefixKey}:EnabledFor[{percentageIndex}]:Name", "Percentage");
-        data.Should().Contain($"{flagPrefixKey}:EnabledFor[{percentageIndex}]:Parameters:Value", "50");
+        data.Should().Contain($"{flagPrefixKey}:EnabledFor:{percentageIndex}:Name", "Percentage");
+        data.Should().Contain($"{flagPrefixKey}:EnabledFor:{percentageIndex}:Parameters:Value", "50");
 
-        data.Should().Contain($"{flagPrefixKey}:EnabledFor[{timeWindowIndex}]:Name", "TimeWindow");
-        data.Should().Contain($"{flagPrefixKey}:EnabledFor[{timeWindowIndex}]:Parameters:Start", "2023");
-        data.Should().Contain($"{flagPrefixKey}:EnabledFor[{timeWindowIndex}]:Parameters:End", "2024");
+        data.Should().Contain($"{flagPrefixKey}:EnabledFor:{timeWindowIndex}:Name", "TimeWindow");
+        data.Should().Contain($"{flagPrefixKey}:EnabledFor:{timeWindowIndex}:Parameters:Start", "2023");
+        data.Should().Contain($"{flagPrefixKey}:EnabledFor:{timeWindowIndex}:Parameters:End", "2024");
     }
 }

--- a/test/CatConsult.AppConfigConfigurationProvider.Tests/fixtures/feature-flags.json
+++ b/test/CatConsult.AppConfigConfigurationProvider.Tests/fixtures/feature-flags.json
@@ -1,0 +1,26 @@
+{
+  "simpleFlag": {
+    "enabled": true
+  },
+  "complexFlag1": {
+    "enabled": true,
+    "requirementType": "Any",
+    "percentage__Value": 50,
+    "timeWindow__Start": "2023",
+    "timeWindow__End": "2024"
+  },
+  "complexFlag2": {
+    "enabled": false,
+    "requirementType": "All",
+    "percentage__Value": 50,
+    "timeWindow__Start": "2023",
+    "timeWindow__End": "2024"
+  },
+  "complexFlag3": {
+    "enabled": true,
+    "requirementType": null,
+    "percentage__Value": 50,
+    "timeWindow__Start": "2023",
+    "timeWindow__End": "2024"
+  }
+}

--- a/test/CatConsult.AppConfigConfigurationProvider.Tests/fixtures/feature-flags.json
+++ b/test/CatConsult.AppConfigConfigurationProvider.Tests/fixtures/feature-flags.json
@@ -22,5 +22,15 @@
     "percentage__Value": 50,
     "timeWindow__Start": "2023",
     "timeWindow__End": "2024"
+  },
+  "edgeCase1": {
+    "enabled": true,
+    "requirementType": "Any",
+    "alwaysOn": ""
+  },
+  "edgeCase2": {
+    "enabled": true,
+    "requirementType": "Any",
+    "foobar__value": null
   }
 }


### PR DESCRIPTION
This PR adds in support for AWS AppConfig Feature Flag profile types for use with [.NET's FeatureManagement](https://github.com/microsoft/FeatureManagement-Dotnet) package.

