### PR TITLE
Namespaced Feature Flags Support

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,6 +148,8 @@ To get around some of the limitations of how AppConfig lets you construct attrib
   - A filter with parameters should be named `featureFilter__parameterName` and have a value for the parameter (e.g. `"percentage__value": 50`)
     - The provider uses the double underscore (`__`) to separate the filter name from the parameter name
     - You can supply multiple parameters using this scheme (e.g. `"percentage__value": 50, "percentage__foobar": "baz"`)
+  - Namespaced filters are support with the usage of a single underscore (`_`) (e.g. `"namespace_featureFilter": null` -> `Namespace.FeatureFilter`)
+  - Extremely complex filters with deeply nested attributes are not supported (ex. `Microsoft.Targeting` and its parameters)
 
 There are likely to be some limitations with this approach, so please open an issue if you find any that don't match your use case.
 

--- a/src/CatConsult.AppConfigConfigurationProvider/CatConsult.AppConfigConfigurationProvider.csproj
+++ b/src/CatConsult.AppConfigConfigurationProvider/CatConsult.AppConfigConfigurationProvider.csproj
@@ -22,7 +22,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="AWSSDK.AppConfigData" Version="3.7.300.16" />
+    <PackageReference Include="AWSSDK.AppConfigData" Version="3.7.300.32" />
     <PackageReference Include="CatConsult.ConfigurationParsers" Version="2.1.0" />
     <PackageReference Include="Humanizer.Core" Version="2.14.1" />
     <PackageReference Include="Microsoft.Extensions.Configuration" Version="6.0.0" />

--- a/test/CatConsult.AppConfigConfigurationProvider.Tests/AppConfigConfigurationProviderTests.cs
+++ b/test/CatConsult.AppConfigConfigurationProvider.Tests/AppConfigConfigurationProviderTests.cs
@@ -150,10 +150,16 @@ public class AppConfigConfigurationProviderTests
 
         VerifyValue(sut, $"{prefix}:EdgeCase1:RequirementType", "Any");
         VerifyValue(sut, $"{prefix}:EdgeCase1:EnabledFor:0:Name", "AlwaysOn");
-        
+
         VerifyValue(sut, $"{prefix}:EdgeCase2:RequirementType", "Any");
         VerifyValue(sut, $"{prefix}:EdgeCase2:EnabledFor:0:Name", "Foobar");
         VerifyValue(sut, $"{prefix}:EdgeCase2:EnabledFor:0:Parameters:Value", null);
+
+        VerifyValue(sut, $"{prefix}:Namespaced.Case1", "true");
+
+        VerifyValue(sut, $"{prefix}:Namespaced.Case2:RequirementType", "Any");
+        VerifyValue(sut, $"{prefix}:Namespaced.Case2:EnabledFor:0:Name", "Microsoft.Percentage");
+        VerifyValue(sut, $"{prefix}:Namespaced.Case2:EnabledFor:0:Parameters:Value", "100");
     }
 
     // Helper methods

--- a/test/CatConsult.AppConfigConfigurationProvider.Tests/CatConsult.AppConfigConfigurationProvider.Tests.csproj
+++ b/test/CatConsult.AppConfigConfigurationProvider.Tests/CatConsult.AppConfigConfigurationProvider.Tests.csproj
@@ -9,12 +9,12 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Bogus" Version="34.0.2" />
+    <PackageReference Include="Bogus" Version="35.3.0" />
     <PackageReference Include="FluentAssertions" Version="6.12.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
     <PackageReference Include="Moq" Version="4.20.70" />
-    <PackageReference Include="xunit" Version="2.6.2" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.4">
+    <PackageReference Include="xunit" Version="2.6.5" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.6">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>

--- a/test/CatConsult.AppConfigConfigurationProvider.Tests/fixtures/feature-flags.json
+++ b/test/CatConsult.AppConfigConfigurationProvider.Tests/fixtures/feature-flags.json
@@ -32,5 +32,13 @@
     "enabled": true,
     "requirementType": "Any",
     "foobar__value": null
+  },
+  "namespaced_Case1": {
+    "enabled": true
+  },
+  "namespaced_Case2": {
+    "enabled": true,
+    "requirementType": "Any",
+    "microsoft_percentage__Value": 100
   }
 }


### PR DESCRIPTION
This PR adds support for feature flag names that have `.` in them (ex. `Foo.Bar`). 
 
It also adds support for namespaced feature filters such as `Microsoft.Percentage`. 
 
To accomplish this within the constraints of AppConfig's attribute naming scheme, substitue a `_` for each `.`.

Please see `README.md` for more information.
