### PR TITLE
SAFE-1873/1874

### DIFF
--- a/CatConsult.AppConfigConfigurationProvider.sln
+++ b/CatConsult.AppConfigConfigurationProvider.sln
@@ -8,8 +8,8 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution 
 		.editorconfig = .editorconfig
 		.gitattributes = .gitattributes
 		.gitignore = .gitignore
-		README.md = README.md
 		global.json = global.json
+		README.md = README.md
 	EndProjectSection
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "src", "src", "{2EBD0916-3F74-4F30-B57E-CF1B3689B1E6}"
@@ -29,9 +29,6 @@ Global
 		Debug|Any CPU = Debug|Any CPU
 		Release|Any CPU = Release|Any CPU
 	EndGlobalSection
-	GlobalSection(SolutionProperties) = preSolution
-		HideSolutionNode = FALSE
-	EndGlobalSection
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
 		{1DBEE150-2B63-4ABF-BFF0-0A10B96243B6}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{1DBEE150-2B63-4ABF-BFF0-0A10B96243B6}.Debug|Any CPU.Build.0 = Debug|Any CPU
@@ -46,9 +43,15 @@ Global
 		{D8BF1775-AB83-4D76-8BF5-DD650564B089}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{D8BF1775-AB83-4D76-8BF5-DD650564B089}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
 	GlobalSection(NestedProjects) = preSolution
 		{1DBEE150-2B63-4ABF-BFF0-0A10B96243B6} = {2EBD0916-3F74-4F30-B57E-CF1B3689B1E6}
 		{5BCD0D06-51FF-4D7B-A859-691F21B736D8} = {F4804EB1-93DD-4C2C-AB36-98486FC22471}
 		{D8BF1775-AB83-4D76-8BF5-DD650564B089} = {03616476-829B-41EC-B71C-D789761F4B80}
+	EndGlobalSection
+	GlobalSection(ExtensibilityGlobals) = postSolution
+		SolutionGuid = {12AA3B18-1018-4CE9-8106-A1BB667DCFCC}
 	EndGlobalSection
 EndGlobal

--- a/src/CatConsult.AppConfigConfigurationProvider/AppConfigConfigurationProvider.cs
+++ b/src/CatConsult.AppConfigConfigurationProvider/AppConfigConfigurationProvider.cs
@@ -16,7 +16,6 @@ public sealed class AppConfigConfigurationProvider : ConfigurationProvider, IDis
     private readonly IAmazonAppConfigData _client;
     private readonly AppConfigProfile _profile;
     private readonly SemaphoreSlim _lock;
-    private const int DefaultPollIntervalSeconds = 30;
 
     private IDisposable? _reloadChangeToken;
 

--- a/src/CatConsult.AppConfigConfigurationProvider/AppConfigConfigurationProvider.cs
+++ b/src/CatConsult.AppConfigConfigurationProvider/AppConfigConfigurationProvider.cs
@@ -16,6 +16,7 @@ public sealed class AppConfigConfigurationProvider : ConfigurationProvider, IDis
     private readonly IAmazonAppConfigData _client;
     private readonly AppConfigProfile _profile;
     private readonly SemaphoreSlim _lock;
+    private const int DefaultPollIntervalSeconds = 30;
 
     private IDisposable? _reloadChangeToken;
 
@@ -75,7 +76,7 @@ public sealed class AppConfigConfigurationProvider : ConfigurationProvider, IDis
 
             var response = await _client.GetLatestConfigurationAsync(request);
             ConfigurationToken = response.NextPollConfigurationToken;
-            NextPollingTime = DateTimeOffset.UtcNow.AddSeconds(response.NextPollIntervalInSeconds);
+            NextPollingTime = DateTimeOffset.UtcNow.AddSeconds(response.NextPollIntervalInSeconds ?? DefaultPollIntervalSeconds);
 
             // If the remote configuration has changed, the API will send back data and we re-parse
             if (response.ContentLength > 0)

--- a/src/CatConsult.AppConfigConfigurationProvider/AppConfigConfigurationProviderExtensions.cs
+++ b/src/CatConsult.AppConfigConfigurationProvider/AppConfigConfigurationProviderExtensions.cs
@@ -9,6 +9,18 @@ namespace CatConsult.AppConfigConfigurationProvider;
 // ReSharper disable UnusedType.Global
 // ReSharper disable UnusedMember.Global
 // ReSharper disable MemberCanBePrivate.Global
+
+/// <summary>
+/// Defines the configuration.AddAppConfig() extension method that consumer applications
+/// call to register AppConfig configuration providers into IConfigurationBuilder builder
+///
+/// The IConfigurationBuilder is ASP.NET's pipeline for assembling configuration sources
+/// during application startup. Each source added via builder.Add(...) contributes
+/// key/value pairs that are merged into the single IConfiguration tree the application consumes
+/// 
+/// For each profile defined in AppConfigOptions.Profiles and AppConfigOptions.FeatureFlags,
+/// we register a separate AppConfigConfigurationProvider instance that independently fetches and refreshes configuration data from AWS AppConfig for that profile
+/// </summary>
 public static class AppConfigConfigurationProviderExtensions
 {
     public const string DefaultSectionName = "AppConfig";
@@ -30,10 +42,14 @@ public static class AppConfigConfigurationProviderExtensions
         string sectionName = DefaultSectionName
     )
     {
+        // Read the "AppConfig" section from the current configuration
+        // (populated from appsettings.$ENV.json) to determine
+        // which AWS AppConfig profiles and feature flags to load
         var options = builder.Build()
             .GetSection(sectionName)
             .Get<AppConfigOptions>() ?? new AppConfigOptions();
 
+        // Convert each profile string entry (Application:Environment:Profile format) into an AppConfigProfile object
         var profiles = options.Profiles.Select(p =>
             AppConfigProfileParser.Parse(p, false, options.Defaults.ReloadAfter)
         );
@@ -42,6 +58,7 @@ public static class AppConfigConfigurationProviderExtensions
             AppConfigProfileParser.Parse(p, true, options.Defaults.ReloadAfter)
         );
 
+        // Register one AppConfigConfigurationProvider per profile by creating an AppConfigConfigurationSource and adding it to the builder
         foreach (var profile in profiles.Concat(featureFlagProfiles))
         {
             builder.Add(

--- a/src/CatConsult.AppConfigConfigurationProvider/AppConfigConfigurationSource.cs
+++ b/src/CatConsult.AppConfigConfigurationProvider/AppConfigConfigurationSource.cs
@@ -4,6 +4,18 @@ using Microsoft.Extensions.Configuration;
 
 namespace CatConsult.AppConfigConfigurationProvider;
 
+
+/// <summary>
+/// Implements IConfigurationSource, which is ASP.NET's abstraction for registering a configuration provider into the configuration pipeline
+///
+/// A configuration provider is a class that knows how to read configuration data from
+/// a specific source and supply it as flattened key/value pairs to the application
+/// 
+/// AppConfigConfigurationProvider is a custom provider that does this with AWS AppConfig as its data source
+/// It fetches JSON/YAML from AppConfig, flattens it into key/value pairs, and feeds them into the IConfiguration tree alongside everything else
+///
+/// This class acts as a lightweight factory that constructs a single AppConfigConfigurationProvider instance for a given AppConfigProfile
+/// </summary>
 public sealed class AppConfigConfigurationSource : IConfigurationSource
 {
     private readonly AppConfigConfigurationProvider _provider;

--- a/src/CatConsult.AppConfigConfigurationProvider/AppConfigOptions.cs
+++ b/src/CatConsult.AppConfigConfigurationProvider/AppConfigOptions.cs
@@ -1,15 +1,37 @@
-﻿namespace CatConsult.AppConfigConfigurationProvider;
+﻿using System.Collections.Generic;
 
+namespace CatConsult.AppConfigConfigurationProvider;
+
+
+/// <summary>
+/// Options that define which AWS AppConfig configuration sources to load at startup
+/// Populated from the "AppConfig" section in appsettings.$ENV.json.
+///
+/// Each profile's AppConfig data can contain a mix of regular config values and Secrets Manager ARN references
+/// When secret resolution is enabled in SecretsManagerOptions, the provider detects ARN values and resolves them to their actual secret strings
+/// </summary>
 public class AppConfigOptions
 {
+    // List of AWS AppConfig hosted configuration profile identifiers to load (format: "ApplicationId:EnvironmentId:ProfileId")
     public List<string> Profiles { get; set; } = new();
 
+    // List of AppConfig feature flag profile identifiers to load (same format as Profiles)
     public List<string> FeatureFlags { get; set; } = new();
 
     public Defaults Defaults { get; set; } = new();
+
+    public SecretsManagerOptions SecretsManager { get; set; } = new();
 }
 
 public class Defaults
 {
     public int ReloadAfter { get; set; } = 60;
+}
+
+public class SecretsManagerOptions
+{
+    public bool Enabled { get; set; } = false;
+
+    // How long in seconds resolved secrets remain cached before being re-fetched. Default: 300 (5 minutes)
+    public int CacheTtlSeconds { get; set; } = 300;
 }

--- a/src/CatConsult.AppConfigConfigurationProvider/AppConfigOptions.cs
+++ b/src/CatConsult.AppConfigConfigurationProvider/AppConfigOptions.cs
@@ -1,6 +1,4 @@
-﻿using System.Collections.Generic;
-
-namespace CatConsult.AppConfigConfigurationProvider;
+﻿namespace CatConsult.AppConfigConfigurationProvider;
 
 
 /// <summary>

--- a/src/CatConsult.AppConfigConfigurationProvider/AppConfigOptions.cs
+++ b/src/CatConsult.AppConfigConfigurationProvider/AppConfigOptions.cs
@@ -28,7 +28,7 @@ public class Defaults
 
 public class SecretsManagerOptions
 {
-    public bool Enabled { get; set; } = false;
+    public bool Enabled { get; set; } = true;
 
     // How long in seconds resolved secrets remain cached before being re-fetched. Default: 300 (5 minutes)
     public int CacheTtlSeconds { get; set; } = 300;

--- a/src/CatConsult.AppConfigConfigurationProvider/AppConfigProfile.cs
+++ b/src/CatConsult.AppConfigConfigurationProvider/AppConfigProfile.cs
@@ -1,8 +1,22 @@
 namespace CatConsult.AppConfigConfigurationProvider;
 
+
+/// <summary>
+/// Represents a single AWS AppConfig configuration profile
+///
+/// AWS AppConfig organizes configuration data in a hierarchy:
+///   Application -> Environment -> Configuration Profile(s)
+///
+/// Configuration Profile: A specific configuration document within that application/environment.
+///
+/// In appsettings.$ENV.json, profiles are declared as colon-delimited strings: "ApplicationId:EnvironmentId:ProfileId"
+/// </summary>
 public record AppConfigProfile(string ApplicationId, string EnvironmentId, string ProfileId)
 {
+    // Indicates whether the profile is a feature flag configuration profile
+    // Feature flag profiles are parsed differently, we use FeatureFlagsProfileParser instead of the standard JSON/YAML parser
     public bool IsFeatureFlag { get; set; }
 
+    // polling interval in seconds that controls how often configuration refresh attempts are made
     public int? ReloadAfter { get; set; }
 }

--- a/src/CatConsult.AppConfigConfigurationProvider/CatConsult.AppConfigConfigurationProvider.csproj
+++ b/src/CatConsult.AppConfigConfigurationProvider/CatConsult.AppConfigConfigurationProvider.csproj
@@ -24,6 +24,7 @@
 
     <ItemGroup>
         <PackageReference Include="AWSSDK.AppConfigData" Version="4.0.2.16" />
+        <PackageReference Include="AWSSDK.SecretsManager" Version="4.0.4.7" />
         <PackageReference Include="CatConsult.ConfigurationParsers" Version="3.0.0" />
         <PackageReference Include="Humanizer.Core" Version="2.14.1" />
         <PackageReference Include="Microsoft.Extensions.Configuration" Version="6.0.0" />

--- a/src/CatConsult.AppConfigConfigurationProvider/CatConsult.AppConfigConfigurationProvider.csproj
+++ b/src/CatConsult.AppConfigConfigurationProvider/CatConsult.AppConfigConfigurationProvider.csproj
@@ -1,41 +1,42 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
-  <PropertyGroup>
-      <TargetFramework>net6.0</TargetFramework>
-      <ImplicitUsings>enable</ImplicitUsings>
-    <Nullable>enable</Nullable>
+    <PropertyGroup>
+        <TargetFramework>net6.0</TargetFramework>
+        <ImplicitUsings>enable</ImplicitUsings>
+        <Nullable>enable</Nullable>
 
-    <PackageId>CatConsult.AppConfigConfigurationProvider</PackageId>
-    <PackageLicenseExpression>MIT</PackageLicenseExpression>
-    <PackageReadmeFile>README.md</PackageReadmeFile>
-    <PackageProjectUrl>https://github.com/Catalyst-Consulting-Group/appconfig-configuration-provider</PackageProjectUrl>
-    <PackageTags>Configuration</PackageTags>
+        <PackageId>CatConsult.AppConfigConfigurationProvider</PackageId>
+        <PackageLicenseExpression>MIT</PackageLicenseExpression>
+        <PackageReadmeFile>README.md</PackageReadmeFile>
+        <PackageProjectUrl>https://github.com/Catalyst-Consulting-Group/appconfig-configuration-provider</PackageProjectUrl>
+        <PackageTags>Configuration</PackageTags>
 
-    <Description>
-      An opinionated .NET Configuration Provider for AWS AppConfig
-    </Description>
-    <Authors>Derek McKinnon</Authors>
-    <Company>Catalyst Consulting Group, Inc.</Company>
+        <Description>
+            An opinionated .NET Configuration Provider for AWS AppConfig
+        </Description>
+        <Authors>Derek McKinnon</Authors>
+        <Company>Catalyst Consulting Group, Inc.</Company>
 
-    <IncludeSymbols>true</IncludeSymbols>
-    <SymbolPackageFormat>snupkg</SymbolPackageFormat>
-  </PropertyGroup>
+        <IncludeSymbols>true</IncludeSymbols>
+        <SymbolPackageFormat>snupkg</SymbolPackageFormat>
+    </PropertyGroup>
 
-  <ItemGroup>
-    <PackageReference Include="AWSSDK.AppConfigData" Version="3.7.300.32" />
-    <PackageReference Include="CatConsult.ConfigurationParsers" Version="2.1.0" />
-    <PackageReference Include="Humanizer.Core" Version="2.14.1" />
-    <PackageReference Include="Microsoft.Extensions.Configuration" Version="6.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="6.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="6.0.0" />
-  </ItemGroup>
+    <ItemGroup>
+        <PackageReference Include="AWSSDK.AppConfigData" Version="4.0.2.15" />
+        <PackageReference Include="AWSSDK.SecretsManager" Version="4.0.4.6" />
+        <PackageReference Include="CatConsult.ConfigurationParsers" Version="2.1.0" />
+        <PackageReference Include="Humanizer.Core" Version="2.14.1" />
+        <PackageReference Include="Microsoft.Extensions.Configuration" Version="6.0.0" />
+        <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="6.0.0" />
+        <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="6.0.0" />
+    </ItemGroup>
 
-  <ItemGroup>
-    <None Include="..\..\README.md" Pack="true" PackagePath="\" />
-  </ItemGroup>
-  
-  <ItemGroup>
-    <InternalsVisibleTo Include="CatConsult.AppConfigConfigurationProvider.Tests" />
-  </ItemGroup>
+    <ItemGroup>
+        <None Include="..\..\README.md" Pack="true" PackagePath="\" />
+    </ItemGroup>
+
+    <ItemGroup>
+        <InternalsVisibleTo Include="CatConsult.AppConfigConfigurationProvider.Tests" />
+    </ItemGroup>
 
 </Project>

--- a/src/CatConsult.AppConfigConfigurationProvider/CatConsult.AppConfigConfigurationProvider.csproj
+++ b/src/CatConsult.AppConfigConfigurationProvider/CatConsult.AppConfigConfigurationProvider.csproj
@@ -1,8 +1,8 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
-    <ImplicitUsings>enable</ImplicitUsings>
+      <TargetFramework>net6.0</TargetFramework>
+      <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
 
     <PackageId>CatConsult.AppConfigConfigurationProvider</PackageId>

--- a/src/CatConsult.AppConfigConfigurationProvider/CatConsult.AppConfigConfigurationProvider.csproj
+++ b/src/CatConsult.AppConfigConfigurationProvider/CatConsult.AppConfigConfigurationProvider.csproj
@@ -27,6 +27,7 @@
         <PackageReference Include="AWSSDK.SecretsManager" Version="4.0.4.7" />
         <PackageReference Include="CatConsult.ConfigurationParsers" Version="3.0.0" />
         <PackageReference Include="Humanizer.Core" Version="2.14.1" />
+        <PackageReference Include="Microsoft.Extensions.Caching.Memory" Version="10.0.3" />
         <PackageReference Include="Microsoft.Extensions.Configuration" Version="6.0.0" />
         <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="6.0.0" />
         <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="6.0.0" />

--- a/src/CatConsult.AppConfigConfigurationProvider/Secrets/SecretsManagerArn.cs
+++ b/src/CatConsult.AppConfigConfigurationProvider/Secrets/SecretsManagerArn.cs
@@ -15,8 +15,8 @@ public class SecretsManagerArn
     private const string ArnPrefix = "arn:";
     private const string SecretsManagerService = "secretsmanager";
     private const int ExpectedMinSegments = 7; // ARN format has 7 colon-delimited segments: arn:{partition}:{service}:{region}:{accountId}:secret:{secretName}
-    public string FullArn { get; }  // The full original ARN string (ex: "arn:aws-us-gov:secretsmanager:us-gov-west-1:123456789012:secret:sit/examplesecret")
-    public string Partition { get; }  // AWS partition (ex: "aws" for standard, "aws-us-gov" for GovCloud)
+    public string FullArn { get; } // The full original ARN string (ex: "arn:aws-us-gov:secretsmanager:us-gov-west-1:123456789012:secret:sit/examplesecret")
+    public string Partition { get; } // AWS partition (ex: "aws" for standard, "aws-us-gov" for GovCloud)
     public string Region { get; } // AWS region (ex: "us-gov-west-1")
     public string AccountId { get; }
     public string SecretName { get; }

--- a/src/CatConsult.AppConfigConfigurationProvider/Secrets/SecretsManagerArn.cs
+++ b/src/CatConsult.AppConfigConfigurationProvider/Secrets/SecretsManagerArn.cs
@@ -1,0 +1,92 @@
+﻿namespace CatConsult.AppConfigConfigurationProvider.Secrets;
+
+/// <summary>
+/// Detects whether a configuration value is a Secrets Manager ARN and parses it into its components
+///
+/// Used by the AppConfigConfigurationProvider (todo in SAFE-1875 ticket) to determine which AppConfig values are secret references
+/// that need to be resolved, versus normal config values that should be left as-is
+///
+/// Supports both standard and GovCloud ARN formats:
+///   arn:aws:secretsmanager:{region}:{accountId}:secret:{secretName}
+///   arn:aws-us-gov:secretsmanager:{region}:{accountId}:secret:{secretName}
+/// </summary>
+public class SecretsManagerArn
+{
+    private const string ArnPrefix = "arn:";
+    private const string SecretsManagerService = "secretsmanager";
+    private const int ExpectedMinSegments = 7; // ARN format has 7 colon-delimited segments: arn:{partition}:{service}:{region}:{accountId}:secret:{secretName}
+    public string FullArn { get; }  // The full original ARN string (ex: "arn:aws-us-gov:secretsmanager:us-gov-west-1:123456789012:secret:sit/examplesecret")
+    public string Partition { get; }  // AWS partition (ex: "aws" for standard, "aws-us-gov" for GovCloud)
+    public string Region { get; } // AWS region (ex: "us-gov-west-1")
+    public string AccountId { get; }
+    public string SecretName { get; }
+
+    private SecretsManagerArn(string fullArn, string partition, string region, string accountId, string secretName)
+    {
+        FullArn = fullArn;
+        Partition = partition;
+        Region = region;
+        AccountId = accountId;
+        SecretName = secretName;
+    }
+
+    // Determines whether a configuration value is an AWS Secrets Manager ARN 
+    public static bool IsSecretsManagerArn(string? value)
+    {
+        if (string.IsNullOrWhiteSpace(value))
+        {
+            return false;
+        }
+
+        return TryParse(value, out _);
+    }
+
+    // Attempts to parse a string into a SecretsManagerArn
+    public static bool TryParse(string? value, out SecretsManagerArn? result)
+    {
+        result = null;
+
+        if (string.IsNullOrWhiteSpace(value) || !value.StartsWith(ArnPrefix, StringComparison.OrdinalIgnoreCase))
+        {
+            return false; // value is not a valid ARN string
+        }
+
+        // ARN format: arn:{partition}:{service}:{region}:{accountId}:secret:{secretName}
+        // Split into max 7 segments (the secret name may contain colons)
+        var segments = value.Split(new[] { ':' }, ExpectedMinSegments);
+
+        if (segments.Length < ExpectedMinSegments)
+        {
+            return false;
+        }
+
+        var partition = segments[1];
+        var service = segments[2]; // should be "secretsmanager"
+        var region = segments[3];
+        var accountId = segments[4];
+        var resourceType = segments[5]; // should be "secret"
+        var secretName = segments[6];
+
+        if (!string.Equals(service, SecretsManagerService, StringComparison.OrdinalIgnoreCase))
+        {
+            return false;
+        }
+
+        if (!string.Equals(resourceType, "secret", StringComparison.OrdinalIgnoreCase))
+        {
+            return false;
+        }
+
+        // If partition or region is invalid, the SecretsManagerSecretResolver Secrets Manager API call will fail with AWS error at app startup
+        if (string.IsNullOrWhiteSpace(partition) ||
+            string.IsNullOrWhiteSpace(region) ||
+            string.IsNullOrWhiteSpace(accountId) ||
+            string.IsNullOrWhiteSpace(secretName))
+        {
+            return false;
+        }
+
+        result = new SecretsManagerArn(value, partition, region, accountId, secretName);
+        return true;
+    }
+}

--- a/src/CatConsult.AppConfigConfigurationProvider/Secrets/SecretsManagerArn.cs
+++ b/src/CatConsult.AppConfigConfigurationProvider/Secrets/SecretsManagerArn.cs
@@ -12,9 +12,6 @@
 /// </summary>
 public class SecretsManagerArn
 {
-    private const string ArnPrefix = "arn:";
-    private const string SecretsManagerService = "secretsmanager";
-    private const int ExpectedMinSegments = 7; // ARN format has 7 colon-delimited segments: arn:{partition}:{service}:{region}:{accountId}:secret:{secretName}
     public string FullArn { get; } // The full original ARN string (ex: "arn:aws-us-gov:secretsmanager:us-gov-west-1:123456789012:secret:sit/examplesecret")
     public string Partition { get; } // AWS partition (ex: "aws" for standard, "aws-us-gov" for GovCloud)
     public string Region { get; } // AWS region (ex: "us-gov-west-1")
@@ -41,52 +38,46 @@ public class SecretsManagerArn
         return TryParse(value, out _);
     }
 
-    // Attempts to parse a string into a SecretsManagerArn
+    // Attempts to parse a string into a SecretsManagerArn using the AWS SDK's built-in Arn parser
     public static bool TryParse(string? value, out SecretsManagerArn? result)
     {
         result = null;
 
-        if (string.IsNullOrWhiteSpace(value) || !value.StartsWith(ArnPrefix, StringComparison.OrdinalIgnoreCase))
+        if (string.IsNullOrWhiteSpace(value) || !Amazon.Arn.IsArn(value))
         {
             return false; // value is not a valid ARN string
         }
 
-        // ARN format: arn:{partition}:{service}:{region}:{accountId}:secret:{secretName}
-        // Split into max 7 segments (the secret name may contain colons)
-        var segments = value.Split(new[] { ':' }, ExpectedMinSegments);
-
-        if (segments.Length < ExpectedMinSegments)
+        Amazon.Arn arn;
+        try
+        {
+            arn = Amazon.Arn.Parse(value);
+        }
+        catch
         {
             return false;
         }
 
-        var partition = segments[1];
-        var service = segments[2]; // should be "secretsmanager"
-        var region = segments[3];
-        var accountId = segments[4];
-        var resourceType = segments[5]; // should be "secret"
-        var secretName = segments[6];
-
-        if (!string.Equals(service, SecretsManagerService, StringComparison.OrdinalIgnoreCase))
+        if (!string.Equals(arn.Service, "secretsmanager", StringComparison.OrdinalIgnoreCase))
         {
             return false;
         }
 
-        if (!string.Equals(resourceType, "secret", StringComparison.OrdinalIgnoreCase))
+        // arn.Resource is "secret:{secretName}"
+        if (!arn.Resource.StartsWith("secret:", StringComparison.OrdinalIgnoreCase))
         {
             return false;
         }
 
-        // If partition or region is invalid, the SecretsManagerSecretResolver Secrets Manager API call will fail with AWS error at app startup
-        if (string.IsNullOrWhiteSpace(partition) ||
-            string.IsNullOrWhiteSpace(region) ||
-            string.IsNullOrWhiteSpace(accountId) ||
-            string.IsNullOrWhiteSpace(secretName))
+        var secretName = arn.Resource.Substring(7); // after "secret:"
+
+        // Reject ARNs with empty or whitespace-only secret names
+        if (string.IsNullOrWhiteSpace(secretName))
         {
             return false;
         }
 
-        result = new SecretsManagerArn(value, partition, region, accountId, secretName);
+        result = new SecretsManagerArn(value!, arn.Partition, arn.Region, arn.AccountId, secretName);
         return true;
     }
 }

--- a/src/CatConsult.AppConfigConfigurationProvider/Secrets/SecretsManagerSecretResolver.cs
+++ b/src/CatConsult.AppConfigConfigurationProvider/Secrets/SecretsManagerSecretResolver.cs
@@ -1,0 +1,127 @@
+﻿using System.Collections.Concurrent;
+using Amazon.SecretsManager;
+using Amazon.SecretsManager.Model;
+
+namespace CatConsult.AppConfigConfigurationProvider.Secrets;
+
+/// <summary>
+/// Resolves AWS Secrets Manager ARN references into their actual secret string values, with in-memory caching
+///
+/// Unlike AppConfig (which provides its own polling interval in API responses),
+/// Secrets Manager has no built-in polling mechanism, so we have a TTL-based cache to avoid re-fetching secrets on every provider reload
+/// Concurrency is handled with a SemaphoreSlim, consistent with the locking pattern used in AppConfigConfigurationProvider
+/// </summary>
+public class SecretsManagerSecretResolver : IDisposable
+{
+    // Time in milliseconds to wait for the lock before giving up
+    private const int LockReleaseTimeout = 3000;
+    // AWS Secrets Manager client used to fetch secret values
+    private readonly IAmazonSecretsManager _client;
+    // How long resolved secrets remain valid in the cache before being re-fetched
+    private readonly TimeSpan _cacheTtl;
+    // Cache keyed by the full ARN string. Each CacheEntry stores the resolved secret value and an expiration timestamp
+    private readonly ConcurrentDictionary<string, CacheEntry> _cache;
+    // Prevents concurrent overlapping fetches to Secrets Manager
+    private readonly SemaphoreSlim _lock;
+
+    // Creates a resolver using a caller-provided Secrets Manager client (used for testing with mocked clients)
+    public SecretsManagerSecretResolver(IAmazonSecretsManager client, int cacheTtlSeconds)
+    {
+        _client = client ?? throw new ArgumentNullException(nameof(client));
+        _cacheTtl = TimeSpan.FromSeconds(cacheTtlSeconds);
+        _cache = new ConcurrentDictionary<string, CacheEntry>(StringComparer.Ordinal);
+        _lock = new SemaphoreSlim(1, 1);
+    }
+
+    // Creates a resolver that instantiates a default AmazonSecretsManagerClient using AWS credentials
+    public SecretsManagerSecretResolver(int cacheTtlSeconds) : this(new AmazonSecretsManagerClient(), cacheTtlSeconds) { }
+
+    // Resolves AWS Secrets Manager ARN reference into its actual secret string value
+    // Returns a cached value if within time-to-live (TTL), otherwise fetch from AWS Secrets Manager and update the cache
+    public async Task<string> ResolveSecretAsync(string arn)
+    {
+        if (string.IsNullOrWhiteSpace(arn))
+        {
+            throw new ArgumentException("ARN cannot be null or empty.", nameof(arn));
+        }
+
+        // Check cache dictionary, if the secret is already there and hasn't expired, return the resolved value
+        if (_cache.TryGetValue(arn, out var cached) && !cached.IsExpired)
+        {
+            return cached.Value;
+        }
+
+        // If lock can't be acquired (another thread is already fetching)
+        if (!await _lock.WaitAsync(LockReleaseTimeout))
+        {
+            // Return the stale cached value if we have one, same approach as AppConfigConfigurationProvider
+            if (cached != null)
+            {
+                return cached.Value;
+            }
+
+            // No cached value exists (first fetch for this secret) and we can't acquire the lock
+            throw new TimeoutException($"Timed out waiting to resolve secret for ARN: {arn}");
+        }
+
+        try
+        {
+            // Check the cache before making AWS call to ensure no other thread already fetched the secret and updated the cache
+            if (_cache.TryGetValue(arn, out cached) && !cached.IsExpired)
+            {
+                return cached.Value;
+            }
+
+            // Lock acquired, fetch the secret value from AWS Secrets Manager and cache it with the TTL
+            var secretValue = await FetchSecretAsync(arn);
+            _cache[arn] = new CacheEntry(secretValue, DateTimeOffset.UtcNow.Add(_cacheTtl));
+            return secretValue;
+        }
+        finally
+        {
+            _lock.Release();
+        }
+    }
+
+    // Given an ARN, fetches the secret string value from AWS Secrets Manager
+    private async Task<string> FetchSecretAsync(string arn)
+    {
+        var request = new GetSecretValueRequest
+        {
+            SecretId = arn
+        };
+
+        var response = await _client.GetSecretValueAsync(request);
+
+        if (response.SecretString != null)
+        {
+            return response.SecretString;
+        }
+
+        throw new InvalidOperationException($"Secret '{arn}' did not return a SecretString value");
+    }
+
+    // Clean up the SemaphoreSlim lock resources when the resolver is no longer needed
+    public void Dispose()
+    {
+        _lock.Dispose();
+    }
+
+    // Represents a cached secret value with an expiration timestamp
+    private class CacheEntry
+    {
+        // The resolved secret string from AWS Secrets Manager
+        public string Value { get; }
+
+        // When this cache entry expires and the secret should be re-fetched
+        public DateTimeOffset ExpiresAtUtc { get; }
+
+        public CacheEntry(string value, DateTimeOffset expiresAtUtc)
+        {
+            Value = value;
+            ExpiresAtUtc = expiresAtUtc;
+        }
+
+        public bool IsExpired => DateTimeOffset.UtcNow >= ExpiresAtUtc;
+    }
+}

--- a/src/CatConsult.AppConfigConfigurationProvider/Secrets/SecretsManagerSecretResolver.cs
+++ b/src/CatConsult.AppConfigConfigurationProvider/Secrets/SecretsManagerSecretResolver.cs
@@ -1,4 +1,4 @@
-﻿using System.Collections.Concurrent;
+﻿using Microsoft.Extensions.Caching.Memory;
 using Amazon.SecretsManager;
 using Amazon.SecretsManager.Model;
 
@@ -8,7 +8,7 @@ namespace CatConsult.AppConfigConfigurationProvider.Secrets;
 /// Resolves AWS Secrets Manager ARN references into their actual secret string values, with in-memory caching
 ///
 /// Unlike AppConfig (which provides its own polling interval in API responses),
-/// Secrets Manager has no built-in polling mechanism, so we have a TTL-based cache to avoid re-fetching secrets on every provider reload
+/// Secrets Manager has no built-in polling mechanism, so we use IMemoryCache with TTL-based expiration to avoid re-fetching secrets on every provider reload
 /// Concurrency is handled with a SemaphoreSlim, consistent with the locking pattern used in AppConfigConfigurationProvider
 /// </summary>
 public class SecretsManagerSecretResolver : IDisposable
@@ -19,8 +19,8 @@ public class SecretsManagerSecretResolver : IDisposable
     private readonly IAmazonSecretsManager _client;
     // How long resolved secrets remain valid in the cache before being re-fetched
     private readonly TimeSpan _cacheTtl;
-    // Cache keyed by the full ARN string. Each CacheEntry stores the resolved secret value and an expiration timestamp
-    private readonly ConcurrentDictionary<string, CacheEntry> _cache;
+    // Cache for resolved secret values - IMemoryCache handles expiration automatically
+    private readonly IMemoryCache _cache;
     // Prevents concurrent overlapping fetches to Secrets Manager
     private readonly SemaphoreSlim _lock;
 
@@ -28,8 +28,8 @@ public class SecretsManagerSecretResolver : IDisposable
     public SecretsManagerSecretResolver(IAmazonSecretsManager client, int cacheTtlSeconds)
     {
         _client = client ?? throw new ArgumentNullException(nameof(client));
+        _cache = new MemoryCache(new MemoryCacheOptions());
         _cacheTtl = TimeSpan.FromSeconds(cacheTtlSeconds);
-        _cache = new ConcurrentDictionary<string, CacheEntry>(StringComparer.Ordinal);
         _lock = new SemaphoreSlim(1, 1);
     }
 
@@ -45,36 +45,30 @@ public class SecretsManagerSecretResolver : IDisposable
             throw new ArgumentException("ARN cannot be null or empty.", nameof(arn));
         }
 
-        // Check cache dictionary, if the secret is already there and hasn't expired, return the resolved value
-        if (_cache.TryGetValue(arn, out var cached) && !cached.IsExpired)
+        // Check cache — if the secret is there and hasn't expired, return the resolved value
+        if (_cache.TryGetValue(arn, out string? cached))
         {
-            return cached.Value;
+            return cached!;
         }
 
         // If lock can't be acquired (another thread is already fetching)
         if (!await _lock.WaitAsync(LockReleaseTimeout))
         {
-            // Return the stale cached value if we have one, same approach as AppConfigConfigurationProvider
-            if (cached != null)
-            {
-                return cached.Value;
-            }
-
-            // No cached value exists (first fetch for this secret) and we can't acquire the lock
+            // IMemoryCache automatically evicts expired entries, so no stale value to fall back on
             throw new TimeoutException($"Timed out waiting to resolve secret for ARN: {arn}");
         }
 
         try
         {
             // Check the cache before making AWS call to ensure no other thread already fetched the secret and updated the cache
-            if (_cache.TryGetValue(arn, out cached) && !cached.IsExpired)
+            if (_cache.TryGetValue(arn, out cached))
             {
-                return cached.Value;
+                return cached!;
             }
 
             // Lock acquired, fetch the secret value from AWS Secrets Manager and cache it with the TTL
             var secretValue = await FetchSecretAsync(arn);
-            _cache[arn] = new CacheEntry(secretValue, DateTimeOffset.UtcNow.Add(_cacheTtl));
+            _cache.Set(arn, secretValue, _cacheTtl);
             return secretValue;
         }
         finally
@@ -101,27 +95,10 @@ public class SecretsManagerSecretResolver : IDisposable
         throw new InvalidOperationException($"Secret '{arn}' did not return a SecretString value");
     }
 
-    // Clean up the SemaphoreSlim lock resources when the resolver is no longer needed
+    // Clean up the cache and lock resources when the resolver is no longer needed
     public void Dispose()
     {
+        _cache.Dispose();
         _lock.Dispose();
-    }
-
-    // Represents a cached secret value with an expiration timestamp
-    private class CacheEntry
-    {
-        // The resolved secret string from AWS Secrets Manager
-        public string Value { get; }
-
-        // When this cache entry expires and the secret should be re-fetched
-        public DateTimeOffset ExpiresAtUtc { get; }
-
-        public CacheEntry(string value, DateTimeOffset expiresAtUtc)
-        {
-            Value = value;
-            ExpiresAtUtc = expiresAtUtc;
-        }
-
-        public bool IsExpired => DateTimeOffset.UtcNow >= ExpiresAtUtc;
     }
 }

--- a/test/CatConsult.AppConfigConfigurationProvider.Tests/CatConsult.AppConfigConfigurationProvider.Tests.csproj
+++ b/test/CatConsult.AppConfigConfigurationProvider.Tests/CatConsult.AppConfigConfigurationProvider.Tests.csproj
@@ -13,7 +13,6 @@
         <PackageReference Include="FluentAssertions" Version="6.12.0" />
         <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
         <PackageReference Include="Moq" Version="4.20.70" />
-        <PackageReference Include="xunit" Version="2.6.5" />
         <PackageReference Include="xunit.runner.visualstudio" Version="2.5.6">
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
             <PrivateAssets>all</PrivateAssets>
@@ -22,6 +21,7 @@
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
             <PrivateAssets>all</PrivateAssets>
         </PackageReference>
+        <PackageReference Include="xunit.v3" Version="3.2.2" />
     </ItemGroup>
 
     <ItemGroup>

--- a/test/CatConsult.AppConfigConfigurationProvider.Tests/SecretsManagerArnTests.cs
+++ b/test/CatConsult.AppConfigConfigurationProvider.Tests/SecretsManagerArnTests.cs
@@ -1,0 +1,118 @@
+using CatConsult.AppConfigConfigurationProvider.Secrets;
+using FluentAssertions;
+
+namespace CatConsult.AppConfigConfigurationProvider.Tests;
+
+public class SecretsManagerArnTests
+{
+    // Valid ARNs
+
+    [Theory]
+    [InlineData("arn:aws:secretsmanager:us-east-1:123456789012:secret:my-secret")]
+    [InlineData("arn:aws:secretsmanager:us-west-2:123456789012:secret:prod/api/key")]
+    [InlineData("arn:aws:secretsmanager:eu-west-1:000000000000:secret:some-secret-AbCdEf")]
+    [InlineData("arn:aws-us-gov:secretsmanager:us-gov-west-1:123456789012:secret:sit/test-secret")]
+    [InlineData("arn:aws-cn:secretsmanager:cn-north-1:123456789012:secret:my-secret")]
+    public void IsSecretsManagerArn_ValidArns_ReturnsTrue(string arn)
+    {
+        SecretsManagerArn.IsSecretsManagerArn(arn).Should().BeTrue();
+    }
+
+    [Fact]
+    public void TryParse_ValidStandardArn_ExtractsCorrectComponents()
+    {
+        const string arn = "arn:aws:secretsmanager:us-east-1:123456789012:secret:my-app/db-password";
+
+        SecretsManagerArn.TryParse(arn, out var result).Should().BeTrue();
+
+        result.Should().NotBeNull();
+        result!.FullArn.Should().Be(arn);
+        result.Partition.Should().Be("aws");
+        result.Region.Should().Be("us-east-1");
+        result.AccountId.Should().Be("123456789012");
+        result.SecretName.Should().Be("my-app/db-password");
+    }
+
+    [Fact]
+    public void TryParse_ValidGovCloudArn_ExtractsCorrectComponents()
+    {
+        const string arn = "arn:aws-us-gov:secretsmanager:us-gov-west-1:123456789012:secret:sit/test-secret";
+
+        SecretsManagerArn.TryParse(arn, out var result).Should().BeTrue();
+
+        result.Should().NotBeNull();
+        result!.Partition.Should().Be("aws-us-gov");
+        result.Region.Should().Be("us-gov-west-1");
+        result.AccountId.Should().Be("123456789012");
+        result.SecretName.Should().Be("sit/test-secret");
+    }
+
+    [Fact]
+    public void TryParse_ArnWithColonsInSecretName_PreservesFullSecretName()
+    {
+        // Secret name portion can contain colons (e.g., version/stage suffixes)
+        const string arn = "arn:aws:secretsmanager:us-east-1:123456789012:secret:my-secret:version-id:stage";
+
+        SecretsManagerArn.TryParse(arn, out var result).Should().BeTrue();
+        result!.SecretName.Should().Be("my-secret:version-id:stage");
+    }
+
+
+    // Invalid ARNs
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("   ")]
+    public void IsSecretsManagerArn_NullOrWhitespace_ReturnsFalse(string? value)
+    {
+        SecretsManagerArn.IsSecretsManagerArn(value).Should().BeFalse();
+    }
+
+    [Fact]
+    public void IsSecretsManagerArn_PlainConfigValue_ReturnsFalse()
+    {
+        SecretsManagerArn.IsSecretsManagerArn("some-config-value").Should().BeFalse();
+    }
+
+    [Theory]
+    [InlineData("arn:aws:s3:::my-bucket")]
+    [InlineData("arn:aws:sqs:us-east-1:123456789012:my-queue")]
+    [InlineData("arn:aws:iam::123456789012:role/my-role")]
+    [InlineData("arn:aws:lambda:us-east-1:123456789012:function:my-function")]
+    [InlineData("arn:aws:dynamodb:us-east-1:123456789012:table/my-table")]
+    public void IsSecretsManagerArn_OtherAwsServiceArns_ReturnsFalse(string arn)
+    {
+        SecretsManagerArn.IsSecretsManagerArn(arn).Should().BeFalse();
+    }
+
+    [Theory]
+    [InlineData("arn:aws:secretsmanager")]
+    [InlineData("arn:aws:secretsmanager:us-east-1")]
+    [InlineData("arn:aws:secretsmanager:us-east-1:123456789012")]
+    [InlineData("arn:aws:secretsmanager:us-east-1:123456789012:secret")]
+    public void IsSecretsManagerArn_TruncatedArns_ReturnsFalse(string arn)
+    {
+        SecretsManagerArn.IsSecretsManagerArn(arn).Should().BeFalse();
+    }
+
+    [Fact]
+    public void IsSecretsManagerArn_WrongResourceType_ReturnsFalse()
+    {
+        // "key" instead of "secret"
+        SecretsManagerArn.IsSecretsManagerArn("arn:aws:secretsmanager:us-east-1:123456789012:key:my-secret").Should().BeFalse();
+    }
+
+    [Fact]
+    public void IsSecretsManagerArn_EmptySecretName_ReturnsFalse()
+    {
+        SecretsManagerArn.IsSecretsManagerArn("arn:aws:secretsmanager:us-east-1:123456789012:secret: ").Should().BeFalse();
+    }
+
+    [Fact]
+    public void TryParse_InvalidArn_OutputsNull()
+    {
+        SecretsManagerArn.TryParse("not-an-arn", out var result).Should().BeFalse();
+        result.Should().BeNull();
+    }
+}

--- a/test/CatConsult.AppConfigConfigurationProvider.Tests/SecretsManagerSecretResolverTests.cs
+++ b/test/CatConsult.AppConfigConfigurationProvider.Tests/SecretsManagerSecretResolverTests.cs
@@ -1,0 +1,222 @@
+using Amazon.SecretsManager;
+using Amazon.SecretsManager.Model;
+using CatConsult.AppConfigConfigurationProvider.Secrets;
+using FluentAssertions;
+using Moq;
+
+namespace CatConsult.AppConfigConfigurationProvider.Tests;
+
+public class SecretsManagerSecretResolverTests
+{
+    private const string TestArn = "arn:aws:secretsmanager:us-east-1:123456789012:secret:test-secret";
+    private const string TestSecretValue = "{\"username\":\"admin\",\"password\":\"s3cr3t\"}";
+    private const int DefaultCacheTtlSeconds = 300;
+
+    private readonly Mock<IAmazonSecretsManager> _mockClient = new();
+
+    [Fact]
+    public async Task ResolveSecretAsync_FetchesSecretFromSecretsManager()
+    {
+        SetupMockResponse(TestArn, TestSecretValue);
+
+        using var sut = new SecretsManagerSecretResolver(_mockClient.Object, DefaultCacheTtlSeconds);
+
+        var result = await sut.ResolveSecretAsync(TestArn);
+
+        result.Should().Be(TestSecretValue);
+        VerifyGetSecretValueCalled(Times.Once()); // Verify only one AWS call was made
+    }
+
+    [Fact]
+    public async Task ResolveSecretAsync_CachedValueReturnedWithinTtl()
+    {
+        SetupMockResponse(TestArn, TestSecretValue);
+
+        using var sut = new SecretsManagerSecretResolver(_mockClient.Object, DefaultCacheTtlSeconds);
+
+        // First call: fetches from AWS
+        var result1 = await sut.ResolveSecretAsync(TestArn);
+        // Second call: should return cached value
+        var result2 = await sut.ResolveSecretAsync(TestArn);
+
+        result1.Should().Be(TestSecretValue);
+        result2.Should().Be(TestSecretValue);
+
+        VerifyGetSecretValueCalled(Times.Once()); // Verify only one AWS call was made
+    }
+
+    [Fact]
+    public async Task ResolveSecretAsync_RefetchesAfterTtlExpires()
+    {
+        const string updatedSecret = "{\"username\":\"admin\",\"password\":\"n3wP@ss\"}";
+
+        // Use a short TTL so it expires between calls
+        const int shortTtlSeconds = 1;
+
+        _mockClient
+            .SetupSequence(c => c.GetSecretValueAsync(
+                It.Is<GetSecretValueRequest>(r => r.SecretId == TestArn),
+                It.IsAny<CancellationToken>()
+            ))
+            .ReturnsAsync(new GetSecretValueResponse { SecretString = TestSecretValue })
+            .ReturnsAsync(new GetSecretValueResponse { SecretString = updatedSecret });
+
+        using var sut = new SecretsManagerSecretResolver(_mockClient.Object, shortTtlSeconds);
+
+        var result1 = await sut.ResolveSecretAsync(TestArn);
+        result1.Should().Be(TestSecretValue);
+
+        // Wait for TTL to expire
+        await Task.Delay(TimeSpan.FromSeconds(shortTtlSeconds + 0.5));
+
+        var result2 = await sut.ResolveSecretAsync(TestArn);
+        result2.Should().Be(updatedSecret);
+
+        VerifyGetSecretValueCalled(Times.Exactly(2)); // Verify exactly 2 AWS calls were made
+    }
+
+    // Verifies that each ARN gets its own independent cache entry, resolving two different ARNs should return two different secret values
+    [Fact]
+    public async Task ResolveSecretAsync_DifferentArns_CachedIndependently()
+    {
+        const string arn2 = "arn:aws:secretsmanager:us-east-1:123456789012:secret:other-secret";
+        const string secret2 = "other-secret-value";
+
+        SetupMockResponse(TestArn, TestSecretValue);
+        SetupMockResponse(arn2, secret2);
+
+        using var sut = new SecretsManagerSecretResolver(_mockClient.Object, DefaultCacheTtlSeconds);
+
+        var result1 = await sut.ResolveSecretAsync(TestArn);
+        var result2 = await sut.ResolveSecretAsync(arn2);
+
+        result1.Should().Be(TestSecretValue);
+        result2.Should().Be(secret2);
+    }
+
+    // Verifies that the lock prevents redundant AWS calls, 10 concurrent requests for the same ARN should result in only a single Secrets Manager fetch
+    [Fact]
+    public async Task ResolveSecretAsync_ConcurrentCalls_OnlySingleFetch()
+    {
+        var callCount = 0;
+
+        _mockClient
+            .Setup(c => c.GetSecretValueAsync(
+                It.Is<GetSecretValueRequest>(r => r.SecretId == TestArn),
+                It.IsAny<CancellationToken>()
+            ))
+            .ReturnsAsync(() =>
+            {
+                Interlocked.Increment(ref callCount);
+                return new GetSecretValueResponse { SecretString = TestSecretValue };
+            });
+
+        using var sut = new SecretsManagerSecretResolver(_mockClient.Object, DefaultCacheTtlSeconds);
+
+        // Fire multiple concurrent resolve calls
+        var tasks = Enumerable.Range(0, 10)
+            .Select(_ => sut.ResolveSecretAsync(TestArn))
+            .ToArray();
+
+        var results = await Task.WhenAll(tasks);
+
+        results.Should().AllBe(TestSecretValue);
+
+        // Only one AWS call should be made
+        callCount.Should().Be(1);
+    }
+
+    // Verifies that AWS access errors propagate to the caller rather than being handled, app should fail at startup with a clear error if it can't access a secret
+    [Fact]
+    public async Task ResolveSecretAsync_AccessDenied_PropagatesException()
+    {
+        _mockClient
+            .Setup(c => c.GetSecretValueAsync(
+                It.IsAny<GetSecretValueRequest>(),
+                It.IsAny<CancellationToken>()
+            ))
+            .ThrowsAsync(new AmazonSecretsManagerException("Access denied"));
+
+        using var sut = new SecretsManagerSecretResolver(_mockClient.Object, DefaultCacheTtlSeconds);
+
+        var act = () => sut.ResolveSecretAsync(TestArn);
+
+        await act.Should().ThrowAsync<AmazonSecretsManagerException>()
+            .WithMessage("*Access denied*");
+    }
+
+    // Verifies that AWS missing/nonexistent secret errors propagate to the caller rather than being handled, app should fail at startup with a clear error if it can't find a secret
+    [Fact]
+    public async Task ResolveSecretAsync_SecretNotFound_PropagatesException()
+    {
+        _mockClient
+            .Setup(c => c.GetSecretValueAsync(
+                It.IsAny<GetSecretValueRequest>(),
+                It.IsAny<CancellationToken>()
+            ))
+            .ThrowsAsync(new ResourceNotFoundException("Secret not found"));
+
+        using var sut = new SecretsManagerSecretResolver(_mockClient.Object, DefaultCacheTtlSeconds);
+
+        var act = () => sut.ResolveSecretAsync(TestArn);
+
+        await act.Should().ThrowAsync<ResourceNotFoundException>();
+    }
+
+    [Fact]
+    public async Task ResolveSecretAsync_BinarySecret_ThrowsInvalidOperationException()
+    {
+        _mockClient
+            .Setup(c => c.GetSecretValueAsync(
+                It.IsAny<GetSecretValueRequest>(),
+                It.IsAny<CancellationToken>()
+            ))
+            .ReturnsAsync(new GetSecretValueResponse
+            {
+                SecretString = null, // binary-only secret
+                SecretBinary = new MemoryStream(new byte[] { 0x00, 0x01 }),
+            });
+
+        using var sut = new SecretsManagerSecretResolver(_mockClient.Object, DefaultCacheTtlSeconds);
+
+        var act = () => sut.ResolveSecretAsync(TestArn);
+
+        await act.Should().ThrowAsync<InvalidOperationException>().WithMessage("*did not return a SecretString value*");
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("   ")]
+    public async Task ResolveSecretAsync_NullOrEmptyArn_ThrowsArgumentException(string? arn)
+    {
+        using var sut = new SecretsManagerSecretResolver(_mockClient.Object, DefaultCacheTtlSeconds);
+
+        var act = () => sut.ResolveSecretAsync(arn!);
+
+        await act.Should().ThrowAsync<ArgumentException>();
+    }
+
+    // Helpers
+
+    private void SetupMockResponse(string arn, string secretValue)
+    {
+        _mockClient
+            .Setup(c => c.GetSecretValueAsync(
+                It.Is<GetSecretValueRequest>(r => r.SecretId == arn),
+                It.IsAny<CancellationToken>()
+            ))
+            .ReturnsAsync(new GetSecretValueResponse
+            {
+                SecretString = secretValue
+            });
+    }
+
+    private void VerifyGetSecretValueCalled(Times times)
+    {
+        _mockClient.Verify(c => c.GetSecretValueAsync(
+            It.IsAny<GetSecretValueRequest>(),
+            It.IsAny<CancellationToken>()
+        ), times);
+    }
+}


### PR DESCRIPTION
**SAFE-1873: AppConfigConfigurationProvider Modernization**
- Update AWSSDK.AppConfigData to V4 (4.0.2.16)
- Fix nullable NextPollIntervalInSeconds from SDK V4 change

**SAFE-1874: Secrets Manager ARN detection & resolution (isolated)**
- Add AWSSDK.SecretsManager V4 dependency
- Add SecretsManagerArn: detects whether a config value is a Secrets Manager ARN vs a normal value
- Add SecretsManagerSecretResolver: resolves ARNs to their actual secret strings, with TTL-based caching and locking consistent with the existing provider
- Add SecretsManagerOptions (Enabled, CacheTtlSeconds) to AppConfigOptions
- Add unit tests for ARN detection and resolver
- No provider wiring yet (this will happen in SAFE-1875)

**General:**
- Added comments across existing files for clarity