### PR TITLE
SAFE-1915: Support JSON secret value parsing in AppConfigConfigurationProvider

### DIFF
--- a/src/CatConsult.AppConfigConfigurationProvider/AppConfigConfigurationProvider.cs
+++ b/src/CatConsult.AppConfigConfigurationProvider/AppConfigConfigurationProvider.cs
@@ -128,8 +128,8 @@ public sealed class AppConfigConfigurationProvider : ConfigurationProvider, IDis
 
     // Iterates over the parsed AppConfig key/value pairs
     // and resolves any Secrets Manager ARN values to their actual secret strings.
-    // If a resolved secret is a JSON object, it's parsed and flattened with the config key as prefix.
-    // Non-ARN values are left unchanged.
+    // If a resolved secret is a JSON object, it's parsed and flattened with the config key as prefix
+    // Non-ARN values are left unchanged
     //
     // Example: AppConfig contains {"AppName":"SAFE", "Database":"arn:aws:secretsmanager:...", "ApiUrl":"https://..."}
     // The ARN resolves to {"Host":"prod-db.amazonaws.com","Credentials":{"Username":"admin","Password":"secret"}}

--- a/src/CatConsult.AppConfigConfigurationProvider/AppConfigConfigurationProvider.cs
+++ b/src/CatConsult.AppConfigConfigurationProvider/AppConfigConfigurationProvider.cs
@@ -1,3 +1,4 @@
+using System.Text;
 using Amazon.AppConfigData;
 using Amazon.AppConfigData.Model;
 
@@ -127,7 +128,18 @@ public sealed class AppConfigConfigurationProvider : ConfigurationProvider, IDis
 
     // Iterates over the parsed AppConfig key/value pairs
     // and resolves any Secrets Manager ARN values to their actual secret strings.
-    // Non-ARN values are left unchanged
+    // If a resolved secret is a JSON object, it's parsed and flattened with the config key as prefix.
+    // Non-ARN values are left unchanged.
+    //
+    // Example: AppConfig contains {"AppName":"SAFE", "Database":"arn:aws:secretsmanager:...", "ApiUrl":"https://..."}
+    // The ARN resolves to {"Host":"prod-db.amazonaws.com","Credentials":{"Username":"admin","Password":"secret"}}
+    // After resolution, the final dictionary is:
+    //   "AppName"                        = "SAFE"
+    //   "Database:Host"                  = "prod-db.amazonaws.com"
+    //   "Database:Credentials:Username"  = "admin"
+    //   "Database:Credentials:Password"  = "secret"
+    //   "ApiUrl"                         = "https://..."
+    // Plain string secrets (non-JSON) are set as single string values
     private async Task<IDictionary<string, string?>> ResolveSecretsAsync(IDictionary<string, string?> parsed)
     {
         var resolved = new Dictionary<string, string?>(parsed.Count, StringComparer.OrdinalIgnoreCase);
@@ -144,7 +156,24 @@ public sealed class AppConfigConfigurationProvider : ConfigurationProvider, IDis
             // ARN detected, resolve to the actual secret string
             try
             {
-                resolved[entry.Key] = await _secretResolver!.ResolveSecretAsync(entry.Value!);
+                var secretValue = await _secretResolver!.ResolveSecretAsync(entry.Value!);
+
+                // If the secret is a JSON object, parse and flatten it with the config key as prefix
+                if (IsJsonObject(secretValue))
+                {
+                    using var stream = new MemoryStream(Encoding.UTF8.GetBytes(secretValue));
+                    var nested = JsonConfigurationParser.Parse(stream);
+
+                    foreach (var nestedEntry in nested)
+                    {
+                        resolved[$"{entry.Key}:{nestedEntry.Key}"] = nestedEntry.Value;
+                    }
+                }
+                else
+                {
+                    // Plain string secret, set as single value
+                    resolved[entry.Key] = secretValue;
+                }
             }
             catch (Exception ex)
             {
@@ -154,6 +183,12 @@ public sealed class AppConfigConfigurationProvider : ConfigurationProvider, IDis
         }
 
         return resolved;
+    }
+
+    // Checks if a resolved secret value is a JSON object by looking for a leading '{'
+    private static bool IsJsonObject(string value)
+    {
+        return value.TrimStart().StartsWith("{");
     }
 
     // Opens a new session with AWS AppConfig for this provider's AppConfig profile

--- a/test/CatConsult.AppConfigConfigurationProvider.Tests/AppConfigConfigurationProviderSecretsIntegrationTests.cs
+++ b/test/CatConsult.AppConfigConfigurationProvider.Tests/AppConfigConfigurationProviderSecretsIntegrationTests.cs
@@ -95,6 +95,109 @@ public class AppConfigConfigurationProviderSecretsIntegrationTests
         emptyValue.Should().Be("");
     }
 
+    // Verifies that when a resolved secret is a JSON object, it's parsed and flattened with the original config key as prefix
+    [Fact]
+    public void Load_WhenEnabled_JsonSecretFlattenedWithPrefix()
+    {
+        const string jsonSecret = @"{""Username"":""admin"",""Password"":""secret""}";
+
+        var resolver = CreateResolver();
+        SetupSecretsManagerResponse(TestArn, jsonSecret);
+
+        var sut = CreateProvider(
+            configJson: $@"{{""Database"":""{TestArn}""}}",
+            secretResolver: resolver
+        );
+
+        sut.Load();
+
+        // JSON secret should be flattened with "Database" as prefix
+        sut.TryGet("Database:Username", out var username).Should().BeTrue();
+        username.Should().Be("admin");
+
+        sut.TryGet("Database:Password", out var password).Should().BeTrue();
+        password.Should().Be("secret");
+
+        // The original key should not exist as a single value
+        sut.TryGet("Database", out _).Should().BeFalse();
+    }
+
+    // Verifies that nested JSON secrets are fully flattened with colon-delimited keys
+    [Fact]
+    public void Load_WhenEnabled_NestedJsonSecretFullyFlattened()
+    {
+        const string nestedJsonSecret = @"{""Db"":{""Host"":""localhost"",""Port"":""5432""}}";
+
+        var resolver = CreateResolver();
+        SetupSecretsManagerResponse(TestArn, nestedJsonSecret);
+
+        var sut = CreateProvider(
+            configJson: $@"{{""Connection"":""{TestArn}""}}",
+            secretResolver: resolver
+        );
+
+        sut.Load();
+
+        // Nested JSON should be fully flattened: Connection:Db:Host, Connection:Db:Port
+        sut.TryGet("Connection:Db:Host", out var host).Should().BeTrue();
+        host.Should().Be("localhost");
+
+        sut.TryGet("Connection:Db:Port", out var port).Should().BeTrue();
+        port.Should().Be("5432");
+    }
+
+    // Verifies that plain string secrets still resolve as single string values
+    [Fact]
+    public void Load_WhenEnabled_PlainStringSecretUnchanged()
+    {
+        const string plainSecret = "my-api-key-12345";
+
+        var resolver = CreateResolver();
+        SetupSecretsManagerResponse(TestArn, plainSecret);
+
+        var sut = CreateProvider(
+            configJson: $@"{{""ApiKey"":""{TestArn}""}}",
+            secretResolver: resolver
+        );
+
+        sut.Load();
+
+        // Plain string should be set as a single value, not parsed as JSON
+        sut.TryGet("ApiKey", out var value).Should().BeTrue();
+        value.Should().Be(plainSecret);
+    }
+
+    // Verifies that a mix of JSON and plain string secrets are handled correctly in the same config
+    [Fact]
+    public void Load_WhenEnabled_MixedJsonAndStringSecrets()
+    {
+        const string jsonArn = "arn:aws:secretsmanager:us-east-1:123456789012:secret:db-creds";
+        const string jsonSecret = @"{""User"":""admin"",""Pass"":""s3cr3t""}";
+        const string stringSecret = "plain-api-key";
+
+        var resolver = CreateResolver();
+        SetupSecretsManagerResponse(jsonArn, jsonSecret);
+        SetupSecretsManagerResponse(TestArn, stringSecret);
+
+        var sut = CreateProvider(
+            configJson: $@"{{""Database"":""{jsonArn}"",""ApiKey"":""{TestArn}""}}",
+            secretResolver: resolver
+        );
+
+        sut.Load();
+
+        // JSON secret should be flattened
+        sut.TryGet("Database:User", out var user).Should().BeTrue();
+        user.Should().Be("admin");
+
+        sut.TryGet("Database:Pass", out var pass).Should().BeTrue();
+        pass.Should().Be("s3cr3t");
+
+        // Plain string secret should be a single value
+        sut.TryGet("ApiKey", out var apiKey).Should().BeTrue();
+        apiKey.Should().Be(stringSecret);
+    }
+
     // Enabled = false: ARN values should NOT be resolved
 
     // Verifies that when secret resolution is disabled , ARN values are left as raw ARN strings in the config - no resolution attempt is made


### PR DESCRIPTION
The current Secrets Manager integration treats all resolved secrets as plain string values. However, secrets stored in AWS Secrets Manager are commonly JSON objects (ex: {"username":"admin","password":"secret"}). This PR adds JSON detection and flattening so that JSON secrets are parsed and merged into the IConfiguration tree with the original config key as a prefix. Plain string secrets continue to resolve as single string values.

**Example:**
AppConfig contains "Database": "arn:aws:secretsmanager:..." which resolves to {"Host":"localhost","Password":"secret"}. After resolution, the IConfiguration tree contains Database:Host = "localhost" and Database:Password = "secret".

**Changes:**
- **AppConfigConfigurationProvider.cs:** Updated ResolveSecretsAsync to detect JSON secrets via IsJsonObject(), parse them with JsonConfigurationParser, and flatten with the config key as prefix. Plain string secrets are unchanged.
- **AppConfigConfigurationProviderSecretsIntegrationTests.cs:** Added tests for JSON flattening with prefix, nested JSON flattening, plain string secrets unchanged, and mixed JSON/string secrets in the same config.