### PR TITLE
SAFE-1990: Add _hasBooted flag to gracefully handle secret resolution failures after initial boot

### DIFF
--- a/src/CatConsult.AppConfigConfigurationProvider/AppConfigConfigurationProvider.cs
+++ b/src/CatConsult.AppConfigConfigurationProvider/AppConfigConfigurationProvider.cs
@@ -100,44 +100,41 @@ public sealed class AppConfigConfigurationProvider : ConfigurationProvider, IDis
                 return;
             }
 
-            try
+            // Initialize session on first call to get the initial configuration token
+            if (string.IsNullOrEmpty(ConfigurationToken))
             {
-                // Initialize session on first call to get the initial configuration token
-                if (string.IsNullOrEmpty(ConfigurationToken))
-                {
-                    await InitializeAppConfigSessionAsync();
-                }
-
-                var request = new GetLatestConfigurationRequest
-                {
-                    ConfigurationToken = ConfigurationToken
-                };
-
-                // Call GetLatestConfiguration - AWS returns data only if config has changed since the last token
-                var response = await _client.GetLatestConfigurationAsync(request);
-                ConfigurationToken = response.NextPollConfigurationToken;
-                NextPollingTime = DateTimeOffset.UtcNow.AddSeconds(response.NextPollIntervalInSeconds ?? 15);
-
-                // If the remote configuration has changed, the API will send back data and we re-parse the response (JSON/YAML) into flattened key/value pairs
-                if (response.ContentLength > 0)
-                {
-                    var parsed = ParseConfig(response.Configuration, response.ContentType);
-                    // If secret resolution is enabled, detect and resolve any Secrets Manager ARN values from AWS AppConfig into actual secret values
-                    // Update the Data dictionary field (which ASP.NET reads from when the consumer app accesses IConfiguration)
-                    Data = _secretResolver != null ? await ResolveSecretsAsync(parsed) : parsed;
-                    // Call OnReload() to notify ASP.NET that config values have changed, allowing
-                    // consumers using IOptionsMonitor<T> to automatically pick up new values without a restart
-                    OnReload();
-                }
-
-                _hasBooted = true;
+                await InitializeAppConfigSessionAsync();
             }
-            catch (Exception ex) when (_hasBooted)
+
+            var request = new GetLatestConfigurationRequest
             {
-                // After initial boot, log the error but keep running with previously loaded config
-                _logger.LogError(ex, "Failed to reload configuration for profile {Profile}. Keeping previously loaded config.",
-                    $"{_profile.ApplicationId}:{_profile.EnvironmentId}:{_profile.ProfileId}");
+                ConfigurationToken = ConfigurationToken
+            };
+
+            // Call GetLatestConfiguration - AWS returns data only if config has changed since the last token
+            var response = await _client.GetLatestConfigurationAsync(request);
+            ConfigurationToken = response.NextPollConfigurationToken;
+            NextPollingTime = DateTimeOffset.UtcNow.AddSeconds(response.NextPollIntervalInSeconds ?? 15);
+
+            // If the remote configuration has changed, the API will send back data and we re-parse the response (JSON/YAML) into flattened key/value pairs
+            if (response.ContentLength > 0)
+            {
+                var parsed = ParseConfig(response.Configuration, response.ContentType);
+                // If secret resolution is enabled, detect and resolve any Secrets Manager ARN values from AWS AppConfig into actual secret values
+                // Update the Data dictionary field (which ASP.NET reads from when the consumer app accesses IConfiguration)
+                Data = _secretResolver != null ? await ResolveSecretsAsync(parsed) : parsed;
+                // Call OnReload() to notify ASP.NET that config values have changed, allowing
+                // consumers using IOptionsMonitor<T> to automatically pick up new values without a restart
+                OnReload();
             }
+
+            _hasBooted = true;
+        }
+        catch (Exception ex) when (_hasBooted)
+        {
+            // After initial boot, log the error but keep running with previously loaded config
+            _logger.LogError(ex, "Failed to reload configuration for profile {Profile}. Keeping previously loaded config.",
+                $"{_profile.ApplicationId}:{_profile.EnvironmentId}:{_profile.ProfileId}");
         }
         finally
         {

--- a/src/CatConsult.AppConfigConfigurationProvider/AppConfigConfigurationProvider.cs
+++ b/src/CatConsult.AppConfigConfigurationProvider/AppConfigConfigurationProvider.cs
@@ -38,7 +38,7 @@ public sealed class AppConfigConfigurationProvider : ConfigurationProvider, IDis
     // Tracks whether the provider has completed its first successful load
     // On first boot (_hasBooted = false), secret resolution failures crash the app so config issues are caught immediately
     // After boot (_hasBooted = true), failures log the error and keep the previously loaded config
-    private bool _hasBooted;
+    private bool _hasBooted = false;
     // Reference to the recurring timer that calls Load() on an interval (set by ReloadAfter) to re-fetch configuration from AppConfig
     // Null until the first Load() call sets it up
     private IDisposable? _reloadChangeToken;

--- a/src/CatConsult.AppConfigConfigurationProvider/AppConfigConfigurationProvider.cs
+++ b/src/CatConsult.AppConfigConfigurationProvider/AppConfigConfigurationProvider.cs
@@ -7,6 +7,8 @@ using CatConsult.AppConfigConfigurationProvider.Utilities;
 using CatConsult.ConfigurationParsers;
 
 using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
 using Microsoft.Extensions.Primitives;
 
 namespace CatConsult.AppConfigConfigurationProvider;
@@ -32,21 +34,27 @@ public sealed class AppConfigConfigurationProvider : ConfigurationProvider, IDis
     private readonly AppConfigProfile _profile; // The specific AppConfig profile this provider instance is responsible for fetching
     private readonly SemaphoreSlim _lock; // Prevents concurrent overlapping fetches to AppConfig
     private readonly SecretsManagerSecretResolver? _secretResolver; // Optional secret resolver - null when SecretsManager is disabled, non-null when enabled
+    private readonly ILogger _logger; // Logger for error reporting during reload failures
+    // Tracks whether the provider has completed its first successful load
+    // On first boot (_hasBooted = false), secret resolution failures crash the app so config issues are caught immediately
+    // After boot (_hasBooted = true), failures log the error and keep the previously loaded config
+    private bool _hasBooted;
     // Reference to the recurring timer that calls Load() on an interval (set by ReloadAfter) to re-fetch configuration from AppConfig
     // Null until the first Load() call sets it up
     private IDisposable? _reloadChangeToken;
 
-    // Constructor for testing — accepts mocked AppConfig client and an optional secret resolver
-    public AppConfigConfigurationProvider(IAmazonAppConfigData client, AppConfigProfile profile, SecretsManagerSecretResolver? secretResolver = null)
+    // Constructor for testing — accepts mocked AppConfig client, an optional secret resolver, and an optional logger
+    public AppConfigConfigurationProvider(IAmazonAppConfigData client, AppConfigProfile profile, SecretsManagerSecretResolver? secretResolver = null, ILogger? logger = null)
     {
         _profile = profile;
         _client = client;
         _lock = new SemaphoreSlim(1, 1);
         _secretResolver = secretResolver;
+        _logger = logger ?? NullLogger.Instance;
     }
 
-    public AppConfigConfigurationProvider(AppConfigProfile profile, SecretsManagerSecretResolver? secretResolver = null)
-        : this(new AmazonAppConfigDataClient(), profile, secretResolver) { }
+    public AppConfigConfigurationProvider(AppConfigProfile profile, SecretsManagerSecretResolver? secretResolver = null, ILogger? logger = null)
+        : this(new AmazonAppConfigDataClient(), profile, secretResolver, logger) { }
 
     // Rolling session token from AWS AppConfig - each API response provides the next token to use for the subsequent request
     private string? ConfigurationToken { get; set; }
@@ -112,9 +120,22 @@ public sealed class AppConfigConfigurationProvider : ConfigurationProvider, IDis
             if (response.ContentLength > 0)
             {
                 var parsed = ParseConfig(response.Configuration, response.ContentType);
-                // If secret resolution is enabled, detect and resolve any Secrets Manager ARN values from AWS AppConfig into actual secret values
-                // Update the Data dictionary field (which ASP.NET reads from when the consumer app accesses IConfiguration)
-                Data = _secretResolver != null ? await ResolveSecretsAsync(parsed) : parsed;
+
+                try
+                {
+                    // If secret resolution is enabled, detect and resolve any Secrets Manager ARN values from AWS AppConfig into actual secret values
+                    // Update the Data dictionary field (which ASP.NET reads from when the consumer app accesses IConfiguration)
+                    Data = _secretResolver != null ? await ResolveSecretsAsync(parsed) : parsed;
+                }
+                catch (Exception ex) when (_hasBooted)
+                {
+                    // After initial boot, log the error but keep running with previously loaded config
+                    _logger.LogError(ex, "Failed to resolve secrets during reload for profile {Profile}. Keeping previously loaded config.",
+                        $"{_profile.ApplicationId}:{_profile.EnvironmentId}:{_profile.ProfileId}");
+                    return;
+                }
+
+                _hasBooted = true;
                 // Call OnReload() to notify ASP.NET that config values have changed, allowing
                 // consumers using IOptionsMonitor<T> to automatically pick up new values without a restart
                 OnReload();

--- a/src/CatConsult.AppConfigConfigurationProvider/AppConfigConfigurationProvider.cs
+++ b/src/CatConsult.AppConfigConfigurationProvider/AppConfigConfigurationProvider.cs
@@ -36,7 +36,7 @@ public sealed class AppConfigConfigurationProvider : ConfigurationProvider, IDis
     private readonly SecretsManagerSecretResolver? _secretResolver; // Optional secret resolver - null when SecretsManager is disabled, non-null when enabled
     private readonly ILogger _logger; // Logger for error reporting during reload failures
     // Tracks whether the provider has completed its first successful load
-    // On first boot (_hasBooted = false), secret resolution failures crash the app so config issues are caught immediately
+    // On first boot (_hasBooted = false), failures crash the app so config issues are caught immediately
     // After boot (_hasBooted = true), failures log the error and keep the previously loaded config
     private bool _hasBooted = false;
     // Reference to the recurring timer that calls Load() on an interval (set by ReloadAfter) to re-fetch configuration from AppConfig
@@ -100,45 +100,43 @@ public sealed class AppConfigConfigurationProvider : ConfigurationProvider, IDis
                 return;
             }
 
-            // Initialize session on first call to get the initial configuration token
-            if (string.IsNullOrEmpty(ConfigurationToken))
+            try
             {
-                await InitializeAppConfigSessionAsync();
-            }
-
-            var request = new GetLatestConfigurationRequest
-            {
-                ConfigurationToken = ConfigurationToken
-            };
-
-            // Call GetLatestConfiguration - AWS returns data only if config has changed since the last token
-            var response = await _client.GetLatestConfigurationAsync(request);
-            ConfigurationToken = response.NextPollConfigurationToken;
-            NextPollingTime = DateTimeOffset.UtcNow.AddSeconds(response.NextPollIntervalInSeconds ?? 15);
-
-            // If the remote configuration has changed, the API will send back data and we re-parse the response (JSON/YAML) into flattened key/value pairs
-            if (response.ContentLength > 0)
-            {
-                var parsed = ParseConfig(response.Configuration, response.ContentType);
-
-                try
+                // Initialize session on first call to get the initial configuration token
+                if (string.IsNullOrEmpty(ConfigurationToken))
                 {
+                    await InitializeAppConfigSessionAsync();
+                }
+
+                var request = new GetLatestConfigurationRequest
+                {
+                    ConfigurationToken = ConfigurationToken
+                };
+
+                // Call GetLatestConfiguration - AWS returns data only if config has changed since the last token
+                var response = await _client.GetLatestConfigurationAsync(request);
+                ConfigurationToken = response.NextPollConfigurationToken;
+                NextPollingTime = DateTimeOffset.UtcNow.AddSeconds(response.NextPollIntervalInSeconds ?? 15);
+
+                // If the remote configuration has changed, the API will send back data and we re-parse the response (JSON/YAML) into flattened key/value pairs
+                if (response.ContentLength > 0)
+                {
+                    var parsed = ParseConfig(response.Configuration, response.ContentType);
                     // If secret resolution is enabled, detect and resolve any Secrets Manager ARN values from AWS AppConfig into actual secret values
                     // Update the Data dictionary field (which ASP.NET reads from when the consumer app accesses IConfiguration)
                     Data = _secretResolver != null ? await ResolveSecretsAsync(parsed) : parsed;
-                }
-                catch (Exception ex) when (_hasBooted)
-                {
-                    // After initial boot, log the error but keep running with previously loaded config
-                    _logger.LogError(ex, "Failed to resolve secrets during reload for profile {Profile}. Keeping previously loaded config.",
-                        $"{_profile.ApplicationId}:{_profile.EnvironmentId}:{_profile.ProfileId}");
-                    return;
+                    // Call OnReload() to notify ASP.NET that config values have changed, allowing
+                    // consumers using IOptionsMonitor<T> to automatically pick up new values without a restart
+                    OnReload();
                 }
 
                 _hasBooted = true;
-                // Call OnReload() to notify ASP.NET that config values have changed, allowing
-                // consumers using IOptionsMonitor<T> to automatically pick up new values without a restart
-                OnReload();
+            }
+            catch (Exception ex) when (_hasBooted)
+            {
+                // After initial boot, log the error but keep running with previously loaded config
+                _logger.LogError(ex, "Failed to reload configuration for profile {Profile}. Keeping previously loaded config.",
+                    $"{_profile.ApplicationId}:{_profile.EnvironmentId}:{_profile.ProfileId}");
             }
         }
         finally

--- a/src/CatConsult.AppConfigConfigurationProvider/AppConfigConfigurationProviderExtensions.cs
+++ b/src/CatConsult.AppConfigConfigurationProvider/AppConfigConfigurationProviderExtensions.cs
@@ -4,6 +4,7 @@ using CatConsult.AppConfigConfigurationProvider.Secrets;
 using CatConsult.AppConfigConfigurationProvider.Utilities;
 
 using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Logging;
 
 namespace CatConsult.AppConfigConfigurationProvider;
 
@@ -28,22 +29,23 @@ public static class AppConfigConfigurationProviderExtensions
 
     public static IConfigurationBuilder AddAppConfig(
         this IConfigurationBuilder builder,
-        string sectionName = DefaultSectionName
-    ) => AddAppConfigInternal(builder, null, sectionName);
-
+        string sectionName = DefaultSectionName,
+        ILoggerFactory? loggerFactory = null
+    ) => AddAppConfigInternal(builder, null, sectionName, loggerFactory);
     public static IConfigurationBuilder AddAppConfig(
         this IConfigurationBuilder builder,
         IAmazonAppConfigData client,
-        string sectionName = DefaultSectionName
-    ) => AddAppConfigInternal(builder, client, sectionName);
-
+        string sectionName = DefaultSectionName,
+        ILoggerFactory? loggerFactory = null
+    ) => AddAppConfigInternal(builder, client, sectionName, loggerFactory);
     // Core implementation for AddAppConfig(). Reads AppConfig options from the current configuration
     // optionally creates a shared secret resolver, then registers one AppConfigConfigurationSource
     // per AWS AppConfig profile into the builder so each profile gets its own independent provider
     private static IConfigurationBuilder AddAppConfigInternal(
         this IConfigurationBuilder builder,
         IAmazonAppConfigData? client = null,
-        string sectionName = DefaultSectionName
+        string sectionName = DefaultSectionName,
+        ILoggerFactory? loggerFactory = null
     )
     {
         // Read the "AppConfig" section from the current configuration
@@ -61,6 +63,8 @@ public static class AppConfigConfigurationProviderExtensions
             secretResolver = new SecretsManagerSecretResolver(options.SecretsManager.CacheTtlSeconds);
         }
 
+        // Create a logger for the providers if a logger factory was provided by the consumer app
+        var logger = loggerFactory?.CreateLogger<AppConfigConfigurationProvider>();
         // Convert each profile string entry (Application:Environment:Profile format) into an AppConfigProfile object
         var profiles = options.Profiles.Select(p =>
             AppConfigProfileParser.Parse(p, false, options.Defaults.ReloadAfter)
@@ -75,8 +79,8 @@ public static class AppConfigConfigurationProviderExtensions
         {
             builder.Add(
                 client is null
-                    ? new AppConfigConfigurationSource(profile, secretResolver)
-                    : new AppConfigConfigurationSource(client, profile, secretResolver)
+                    ? new AppConfigConfigurationSource(profile, secretResolver, logger)
+                    : new AppConfigConfigurationSource(client, profile, secretResolver, logger)
             );
         }
 

--- a/src/CatConsult.AppConfigConfigurationProvider/AppConfigConfigurationSource.cs
+++ b/src/CatConsult.AppConfigConfigurationProvider/AppConfigConfigurationSource.cs
@@ -1,6 +1,7 @@
 using Amazon.AppConfigData;
 using CatConsult.AppConfigConfigurationProvider.Secrets;
 using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Logging;
 
 namespace CatConsult.AppConfigConfigurationProvider;
 
@@ -21,12 +22,12 @@ public sealed class AppConfigConfigurationSource : IConfigurationSource
     private readonly AppConfigConfigurationProvider _provider;
 
     // Constructor for testing - accepts mocked AppConfig client and an optional secret resolver
-    public AppConfigConfigurationSource(IAmazonAppConfigData appConfigClient, AppConfigProfile profile, SecretsManagerSecretResolver? secretResolver = null) =>
-        _provider = new AppConfigConfigurationProvider(appConfigClient, profile, secretResolver);
+    public AppConfigConfigurationSource(IAmazonAppConfigData appConfigClient, AppConfigProfile profile, SecretsManagerSecretResolver? secretResolver = null, ILogger? logger = null) =>
+        _provider = new AppConfigConfigurationProvider(appConfigClient, profile, secretResolver, logger);
 
     // Constructor for production - creates default AWS clients internally
-    public AppConfigConfigurationSource(AppConfigProfile profile, SecretsManagerSecretResolver? secretResolver = null) =>
-        _provider = new AppConfigConfigurationProvider(profile, secretResolver);
+    public AppConfigConfigurationSource(AppConfigProfile profile, SecretsManagerSecretResolver? secretResolver = null, ILogger? logger = null) =>
+        _provider = new AppConfigConfigurationProvider(profile, secretResolver, logger);
 
     // Called by ASP.NET's ConfigurationBuilder.Build() to get the provider instance for this source
     public IConfigurationProvider Build(IConfigurationBuilder builder) => _provider;

--- a/src/CatConsult.AppConfigConfigurationProvider/CatConsult.AppConfigConfigurationProvider.csproj
+++ b/src/CatConsult.AppConfigConfigurationProvider/CatConsult.AppConfigConfigurationProvider.csproj
@@ -28,6 +28,7 @@
         <PackageReference Include="CatConsult.ConfigurationParsers" Version="3.0.0" />
         <PackageReference Include="Humanizer.Core" Version="2.14.1" />
         <PackageReference Include="Microsoft.Extensions.Caching.Memory" Version="10.0.3" />
+        <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.7" />
         <PackageReference Include="Microsoft.Extensions.Configuration" Version="6.0.0" />
         <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="6.0.0" />
         <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="6.0.0" />

--- a/test/CatConsult.AppConfigConfigurationProvider.Tests/AppConfigConfigurationProviderSecretsIntegrationTests.cs
+++ b/test/CatConsult.AppConfigConfigurationProvider.Tests/AppConfigConfigurationProviderSecretsIntegrationTests.cs
@@ -277,6 +277,72 @@ public class AppConfigConfigurationProviderSecretsIntegrationTests
         ), Times.Once());
     }
 
+    // _hasBooted behavior
+
+    // Verifies that on first boot (_hasBooted = false), secret resolution failures crash the app so config issues are caught immediately at startup
+    [Fact]
+    public void Load_FirstBootFailure_Throws()
+    {
+        _mockSecretsClient
+            .Setup(c => c.GetSecretValueAsync(
+                It.IsAny<GetSecretValueRequest>(),
+                It.IsAny<CancellationToken>()
+            ))
+            .ThrowsAsync(new Amazon.SecretsManager.Model.ResourceNotFoundException("Secret not found"));
+
+        var resolver = CreateResolver();
+
+        var sut = CreateProvider(
+            configJson: $@"{{""SecretKey"":""{TestArn}""}}",
+            secretResolver: resolver
+        );
+
+        // First boot should throw, app should not start with missing secrets
+        var act = () => sut.Load();
+        act.Should().Throw<InvalidOperationException>();
+    }
+
+    // Verifies that after initial boot (_hasBooted = true),
+    // secret resolution failures log the error and keep the previously loaded config instead of crashing
+    [Fact]
+    public void Load_ReloadFailure_RetainsPreviousConfig()
+    {
+        var configJson = $@"{{""SecretKey"":""{TestArn}"",""NormalKey"":""plain-value""}}";
+
+        // First call succeeds, second call throws
+        _mockSecretsClient
+            .SetupSequence(c => c.GetSecretValueAsync(
+                It.Is<GetSecretValueRequest>(r => r.SecretId == TestArn),
+                It.IsAny<CancellationToken>()
+            ))
+            .ReturnsAsync(new GetSecretValueResponse { SecretString = TestSecretValue })
+            .ThrowsAsync(new Amazon.SecretsManager.Model.ResourceNotFoundException("Secret not found"));
+
+        // Use a short TTL so the cache expires between loads, forcing the second call to hit Secrets Manager
+        const int shortTtlSeconds = 1;
+        var resolver = new SecretsManagerSecretResolver(_mockSecretsClient.Object, shortTtlSeconds);
+        var sut = CreateProviderWithMultipleLoads(configJson, resolver);
+
+        // First load succeeds, _hasBooted becomes true
+        sut.Load();
+        sut.TryGet("SecretKey", out var firstValue).Should().BeTrue();
+        firstValue.Should().Be(TestSecretValue);
+
+        // Wait for cache to expire
+        Thread.Sleep(TimeSpan.FromSeconds(shortTtlSeconds + 0.5));
+
+        // Second load fails, should NOT throw, should keep previous config
+        var act = () => sut.Load();
+        act.Should().NotThrow();
+
+        // Previous config should still be intact
+        sut.TryGet("SecretKey", out var retainedValue).Should().BeTrue();
+        retainedValue.Should().Be(TestSecretValue);
+
+        sut.TryGet("NormalKey", out var normalValue).Should().BeTrue();
+        normalValue.Should().Be("plain-value");
+    }
+
     // Helpers
 
     private SecretsManagerSecretResolver CreateResolver()


### PR DESCRIPTION
Currently, if any failure occurs during configuration loading (initial startup or subsequent reload), the provider throws and the app crashes.

**New Approach:** Added an instance-level _hasBooted flag that flips to true after the first successful load. On reload failures, the provider logs the error and keeps the previously loaded config instead of crashing.

**First boot - secret resolution fails:**
1. builder.Build() in Program.cs
2. calls Load() on the provider
3. calls LoadAsync()
4. fetches config from AppConfig (succeeds)
5. calls ResolveSecretsAsync(parsed)
6. detects ARN, calls _secretResolver.ResolveSecretAsync()
7. AWS throws
8. catch block wraps it: throw new InvalidOperationException(...)
9. exception returns to LoadAsync()
10. hits "catch (Exception ex) when (_hasBooted)"
11. _hasBooted is false -> catch block SKIPPED
12.  exception propagates up through Load() → builder.Build()
13.  app crashes with error message

**After boot - secret resolution fails on reload:**
1. First Load() already completed successfully
2.  _hasBooted set to true
3.  ChangeToken timer set up
4. ReloadAfter interval expires
5. ChangeToken timer calls Load()
6. calls LoadAsync()
7. fetches config from AppConfig (succeeds, config changed)
8. calls ResolveSecretsAsync(parsed)
9. detects ARN, calls _secretResolver.ResolveSecretAsync()
10. AWS throws
11. catch block wraps it: throw new InvalidOperationException(...)
12. exception returns to LoadAsync()
13. hits catch (Exception ex) when (_hasBooted)
14. _hasBooted is true -> catch block EXECUTES
15. logs the error, returns early
16. Config data retains values from the last successful load
17. app keeps running normally

**Changes:**
- AppConfigConfigurationProvider.cs: Added _hasBooted flag, ILogger field (defaults to NullLogger.Instance). In LoadAsync(), wrapped all failure points in LoadAsync with catch (Exception ex) when (_hasBooted) so first boot failures propagate and crash, reload failures (AppConfig API, parsing, secret resolution) log and retain previous config
- AppConfigConfigurationProviderExtensions.cs: Added optional ILoggerFactory parameter to AddAppConfig() and AddAppConfigInternal(). Creates a logger per provider via loggerFactory.CreateLogger<AppConfigConfigurationProvider>() and passes it through to each provider. Defaults to null so existing consumers are unaffected.
- AppConfigConfigurationSource.cs: Updated constructors to pass through optional ILogger
- csproj: Added logging package
- Added tests